### PR TITLE
Support for babysitter invite flow if no number received

### DIFF
--- a/pregnancytext/babysitter-api.js
+++ b/pregnancytext/babysitter-api.js
@@ -157,7 +157,9 @@ exports.onSendBabysitterInvite = function(request, response) {
   var betaPhone = false;
   var args = request.body.args;
   if (!(betaPhone = hasValidPhone(args))) {
-    sendGenericResponse(request.body.phone);
+    if (request.body.dev !== '1') {
+      sendGenericResponse(request.body.phone);
+    }
     response.send("That wasn't a valid phone number.");
     return;
   }
@@ -173,7 +175,9 @@ exports.onSendBabysitterInvite = function(request, response) {
     betaOptin: optinBsOnInvite
   };
 
-  mobilecommons.optin(args);
+  if (request.body.dev !== '1') {
+    mobilecommons.optin(args);
+  }
 
   response.send('OK');
 };
@@ -257,7 +261,9 @@ exports.deliverTips = function(request, response, tipName) {
           alphaOptin: optin
         };
 
-        mobilecommons.optin(args);
+        if (request.body.dev !== '1') {
+          mobilecommons.optin(args);
+        }
 
         // Update the existing doc in the database
         var data = {
@@ -284,7 +290,10 @@ exports.deliverTips = function(request, response, tipName) {
           alphaPhone: request.body.phone,
           alphaOptin: optin
         };
-        mobilecommons.optin(args);
+
+        if (request.body.dev !== '1') {
+          mobilecommons.optin(args);
+        }
 
         // Create a new doc
         var model = new tipModel({


### PR DESCRIPTION
- If a user responds with a message that doesn't include a number, we just send a randomly selected message via Mobile Commons opt in path.
- Also, watching for a `dev` flag from the `request.body` and skipping any requests to Mobile Commons if that's set.
  - Mostly for load testing to prevent 1000s of requests hitting the Mobile Commons API
