### PR TITLE
Restucture tips-config

### DIFF
--- a/lib/ds/tips-api.js
+++ b/lib/ds/tips-api.js
@@ -48,14 +48,7 @@ exports.deliverTips = function(request, response, mdataOverride) {
   }
 
   // Decide tip name based on the mdata id.
-  var tipConfig = undefined;
-  for (var i = 0; i < config.tips.length; i++) {
-    var t = config.tips[i];
-    if (t.mdataId === mdataId) {
-      tipConfig = t;
-      break;
-    }
-  }
+  tipConfig = config.tips[mdataId];
 
   // Config error checking
   if (typeof(tipConfig) === 'undefined'

--- a/lib/ds/tips-config.json
+++ b/lib/ds/tips-config.json
@@ -1,36 +1,39 @@
 {
   "modelName": "Tip",
-  "tips": [
-    {
-      "__comments": "Thumb Wars 2014 - KNOW tips.",
-      "mdataId": 10673,
-      "name": "thumbwars2014-know",
-      "optins": [
-        167263,
-        167265,
-        167269,
-        167271
-      ]
-    },
-    {
-      "__comments": "Thumb Wars 2014 - PLAN tips.",
-      "mdataId": 10663,
-      "name": "thumbwars2014-plan",
-      "optins": [
-        167273,
-        167275,
-        167277
-      ]
-    },
-    {
-      "__comments": "Thumb Wars 2014 - DO tips.",
-      "mdataId": 10243,
-      "name": "thumbwars2014-do",
-      "optins": [
-        167279,
-        167281,
-        167283
-      ]
+  "tips": {
+    "10673":
+      {
+        "__comments": "Thumb Wars 2014 - KNOW tips.",
+        "mdataId": 10673,
+        "name": "thumbwars2014-know",
+        "optins": [
+          167263,
+          167265,
+          167269,
+          167271
+        ]
+      },
+    "10663":
+      {
+        "__comments": "Thumb Wars 2014 - PLAN tips.",
+        "mdataId": 10663,
+        "name": "thumbwars2014-plan",
+        "optins": [
+          167273,
+          167275,
+          167277
+        ]
+      },
+    "10243":
+      {
+        "__comments": "Thumb Wars 2014 - DO tips.",
+        "mdataId": 10243,
+        "name": "thumbwars2014-do",
+        "optins": [
+          167279,
+          167281,
+          167283
+        ]
+      }
     }
-  ]
 }


### PR DESCRIPTION
Fixes #23 
- Restructures `tips-config.json` to use `mdataId` as index for `tips` entries.
- Replace loop logic to collect tip settings from `tips-config.json` with lookup by `mdataId` index value
