### PR TITLE
Adding StatHat reporting to the tips delivery code

### DIFF
--- a/lib/ds/tips-api.js
+++ b/lib/ds/tips-api.js
@@ -4,6 +4,7 @@
 
 var mobilecommons = require('../../mobilecommons/mobilecommons')
     , mongoose = require('mongoose')
+    , stathat = require('stathat')
     , config = require('./tips-config.json')
     ;
 
@@ -25,6 +26,25 @@ var schema = new mongoose.Schema({
 var tipModel = mongoose.model(config.modelName, schema);
 
 /**
+ * @todo Move this out to its own library ds-stathat when more module need to use it.
+ *
+ * Reports a count to StatHat.
+ *
+ * @param statname
+ *   String name of the stat to report on.
+ * @param count
+ *   Number value of the count to report.
+ */
+var stathatReportCount = function(statname, count) {
+  stathat.trackEZCount(
+    process.env.STATHAT_EZ_KEY,
+    statname,
+    count,
+    function(status, json) {}
+  );
+};
+
+/**
  * Progress a user through a series of tips delivered via Mobile Commons opt-in paths.
  *
  * @param request
@@ -37,6 +57,8 @@ var tipModel = mongoose.model(config.modelName, schema);
  */
 exports.deliverTips = function(request, response, mdataOverride) {
   if (typeof(request.body.mdata_id) === 'undefined' && typeof(mdataOverride) === 'undefined') {
+    stathatReportCount('mobilecommons: tips request: error - missing mData ID', 1);
+
     response.send(204);
     return;
   }
@@ -54,6 +76,8 @@ exports.deliverTips = function(request, response, mdataOverride) {
   if (typeof(tipConfig) === 'undefined'
       || typeof(tipConfig.name) === 'undefined'
       || typeof(tipConfig.optins) === 'undefined') {
+    stathatReportCount('mobilecommons: tips request: error - config not set', 1);
+
     response.send(501);
     return;
   }
@@ -114,6 +138,8 @@ exports.deliverTips = function(request, response, mdataOverride) {
 
         if (request.body.dev !== '1') {
           mobilecommons.optin(args);
+
+          stathatReportCount('mobilecommons: tips request: success', 1);
         }
 
         // Update the existing doc in the database
@@ -145,6 +171,8 @@ exports.deliverTips = function(request, response, mdataOverride) {
 
         if (request.body.dev !== '1') {
           mobilecommons.optin(args);
+
+          stathatReportCount('mobilecommons: tips request: success', 1);
         }
 
         // Create a new doc

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "path": "~0.4.9",
         "mongoose": "~3.8.8",
         "mysql": "2.1.x",
-        "request": "2.34.x"
+        "request": "2.34.x",
+        "stathat": "~0.0.8"
     }
 }


### PR DESCRIPTION
@DeeZone I wanted to throw some StatHat tracking into the tips code to go along with the tips refactoring PR.

This just uses a `stathat` library that already existed on npm. Thinking about maybe creating our own internal sort of `ds-stathat` node library to match our usage of StatHat in our message broker code.

But for now, this seems sufficient. Tested and verified the new stats showed up in StatHat.
