### PR TITLE
Database URI set in app config

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -21,6 +21,9 @@ module.exports = function(app, express) {
 
     // Add static path
     app.use(express.static(path.join(root_dirname, 'public')));
+
+    // Set the database URI this app will use.
+    app.set('database-uri', 'mongodb://localhost/ds-mdata-responder');
   });
 
   fs.readdirSync('./app/config').forEach(function(file) {

--- a/app/controllers/Tips.js
+++ b/app/controllers/Tips.js
@@ -9,7 +9,7 @@ var stathat = require('stathat');
 var Tips = function(app) {
   this.app = app;
   this.config = app.get('tips-config');
-  this.tipModel = require('../models/Tip')(this.config.modelName);
+  this.tipModel = require('../models/Tip')(app, this.config.modelName);
 }
 
 module.exports = Tips;

--- a/app/models/Tip.js
+++ b/app/models/Tip.js
@@ -4,10 +4,9 @@
 
 var mongoose = require('mongoose');
 
-var Tip = function(modelName) {
+var Tip = function(app, modelName) {
 
-  var uri = 'mongodb://localhost/ds-mdata-responder-last-tip-delivered';
-  var db = mongoose.createConnection(uri);
+  var db = mongoose.createConnection(app.get('database-uri'));
 
   var schema = new mongoose.Schema({
     phone: String,


### PR DESCRIPTION
#### What's this PR do?

The database uri is now set in the `app` var. The name is changing because some other types of data (SMS games) will now be stored in the database. Deploying this change could cause someone in the middle of the tips flow to restart from the beginning ... which isn't the worst thing in the world. We can minimize this by deploying this change either first thing in the morning or late at night when fewer people will be texting in to get tips.
#### Where should the reviewer start?

The database uri is now set in `app/config/index.js`. This is used in one place in `app/models/Tip.js`. And the app var needs to be passed in so that the `app` config value can actually be referenced.
#### How should this be manually tested?

The only component using the database before was our tips code. So if you POST to `http://locahost:4711/ds/tips` with parameters `phone=<your phone #>&mdata_id=10673` twice, you should get two different messages.
#### What are the relevant tickets?

Closes #52 
