### PR TITLE
Removes deprecated Express methods

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -3,29 +3,30 @@ var fs = require('fs');
 var root_dirname = path.dirname(path.dirname(__dirname));
 
 module.exports = function(app, express) {
-  app.configure(function() {
-    // Set port variable
-    app.set('port', process.env.PORT || 4711);
 
-    // Parses request body and populates request.body
-    app.use(express.bodyParser());
+  // Set port variable
+  app.set('port', process.env.PORT || 4711);
 
-    // Checks request.body for HTTP method override
-    app.use(express.methodOverride());
+  // Parses request body and populates request.body
+  app.use(express.json());
+  app.use(express.urlencoded());
 
-    // Perform route lookup based on url and HTTP method
-    app.use(app.router);
+  // For multi-part parsing
+  app.use(require('connect-multiparty')());
 
-    // Show all errors in development
-    app.use(express.errorHandler({dumpException: true, showStack: true}));
+  // Perform route lookup based on url and HTTP method
+  app.use(app.router);
 
-    // Add static path
-    app.use(express.static(path.join(root_dirname, 'public')));
+  // Show all errors in development
+  app.use(express.errorHandler({dumpException: true, showStack: true}));
 
-    // Set the database URI this app will use.
-    app.set('database-uri', 'mongodb://localhost/ds-mdata-responder');
-  });
+  // Add static path
+  app.use(express.static(path.join(root_dirname, 'public')));
 
+  // Set the database URI this app will use.
+  app.set('database-uri', 'mongodb://localhost/ds-mdata-responder');
+
+  // Read through .json configs in the config folder and set to app variables
   fs.readdirSync('./app/config').forEach(function(file) {
     if (file != path.basename(__filename)) {
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Interface for interacting with DoSomething.org SMS experiences.",
   "dependencies": {
+    "connect-multiparty": "1.1.0",
     "express": "3.x",
     "path": "~0.4.9",
     "mongoose": "~3.8.8",


### PR DESCRIPTION
#### What's this PR do?

Removes methods that Express was warning would be deprecated - `app.configure`, `express.bodyParser` and `express.methodOverride()`.

Since we're not really dealing with dev or production environments with this thing yet, there was no reason for us to use `app.configure`. `express.bodyParser` is now replaced by:

```
app.use(express.json());
app.use(express.urlencoded());
```

And the multipart related warning was fixed with using the connect-multiparty lib directly.

```
app.use(require('connect-multiparty')());
```
#### How should this be manually tested?

I tested both `/ds/tips` and the SMS game stuff. If you want to test, it'd be sufficient to just do a POST to `/ds/tips` and verify your phone receives an SMS.

```
POST to http://localhost:4711/ds/tips
phone=<your phone number here>&mdata_id=9521
```
#### What are the relevant tickets?

Fixes #54 
