### PR TITLE
Creating a single mongo connection that models get created off of

### DIFF
--- a/app/models/sgCollaborativeStory.js
+++ b/app/models/sgCollaborativeStory.js
@@ -1,8 +1,7 @@
 /**
  * Mongoose model for Collaborative Story SMS games.
  */
-var mongoose = require('mongoose')
-    , sgGameSchema = require('./sgGameSchema')()
+var sgGameSchema = require('./sgGameSchema')()
     ;
 
 var sgCollaborativeStory = function(app) {
@@ -41,8 +40,7 @@ var sgCollaborativeStory = function(app) {
     }]
   });
 
-  var db = mongoose.createConnection(app.get('database-uri'));
-  return db.model(modelName, schema);
+  return app.getModel(modelName, schema);
 };
 
 module.exports = sgCollaborativeStory;

--- a/app/models/sgCompetitiveStory.js
+++ b/app/models/sgCompetitiveStory.js
@@ -1,8 +1,7 @@
 /**
  * Mongoose model for Competitive Story SMS games.
  */
-var mongoose = require('mongoose')
-    , sgGameSchema = require('./sgGameSchema')()
+var sgGameSchema = require('./sgGameSchema')()
     ;
 
 var sgCompetitiveStory = function(app) {
@@ -34,8 +33,7 @@ var sgCompetitiveStory = function(app) {
     }]
   });
 
-  var db = mongoose.createConnection(app.get('database-uri'));
-  return db.model(modelName, schema);
+  return app.getModel(modelName, schema);
 };
 
 module.exports = sgCompetitiveStory;

--- a/app/models/sgGameMapping.js
+++ b/app/models/sgGameMapping.js
@@ -19,8 +19,7 @@ var sgGameMapping = function(app) {
     game_model: String
   });
 
-  var db = mongoose.createConnection(app.get('database-uri'));
-  return db.model(modelName, schema);
+  return app.getModel(modelName, schema);
 };
 
 module.exports = sgGameMapping;

--- a/app/models/sgMostLikelyTo.js
+++ b/app/models/sgMostLikelyTo.js
@@ -2,8 +2,7 @@
  * Mongoose model for the Most Likely To SMS game.
  */
 
-var mongoose = require('mongoose')
-    , sgGameSchema = require('./sgGameSchema')()
+var sgGameSchema = require('./sgGameSchema')()
     ;
 
 var sgMostLikelyTo = function(app) {
@@ -31,8 +30,7 @@ var sgMostLikelyTo = function(app) {
     }]
   });
 
-  var db = mongoose.createConnection(app.get('database-uri'));
-  return db.model(modelName, schema);
+  return app.getModel(modelName, schema);
 };
 
 module.exports = sgMostLikelyTo;

--- a/app/models/sgUser.js
+++ b/app/models/sgUser.js
@@ -7,7 +7,6 @@ var mongoose = require('mongoose')
 
 var sgUser = function(app) {
   var modelName = 'sg_user';
-  var db = mongoose.createConnection(app.get('database-uri'));
 
   var schema = new mongoose.Schema({
     // Phone number of this user
@@ -17,9 +16,7 @@ var sgUser = function(app) {
     current_game_id: mongoose.Schema.Types.ObjectId
   });
 
-  var model = db.model(modelName, schema);
-
-  return model;
+  return app.getModel(modelName, schema);
 };
 
 module.exports = sgUser;

--- a/app/models/tip.js
+++ b/app/models/tip.js
@@ -6,8 +6,6 @@ var mongoose = require('mongoose');
 
 var tip = function(app, modelName) {
 
-  var db = mongoose.createConnection(app.get('database-uri'));
-
   var schema = new mongoose.Schema({
     phone: String,
     last_tip_delivered: [{
@@ -16,9 +14,7 @@ var tip = function(app, modelName) {
     }]
   });
 
-  var model = db.model(modelName, schema);
-
-  return model;
+  return app.getModel(modelName, schema);
 };
 
 module.exports = tip;


### PR DESCRIPTION
#### What's this PR do?

Instead of new Mongo connections getting created with each request, a single connection is created once and used to create all Mongoose models needed.
#### Where should the reviewer start?

`app.getModel()` is a helper function created to get or create Mongoose models as needed. This replaces all `db.createConnection` + `db.model` calls throughout the code base.
#### How should this be manually tested?

I was able to reproduce the error before by POSTing to http://localhost:4711/game/create?type=competitive-story with parameters:

```
story_id=1
person[first_name]=jon
person[phone]=13015550100
friends[0][first_name]=friend0
friends[1][first_name]=friend1
friends[2][first_name]=friend2
friends[0][phone]=13015550101
friends[1][phone]=13015550102
friends[2][phone]=13015550103
```

... probably like 50 times in a row. If you watch the mongo logs before this change, you'll see new connections getting created on each POST. Once it gets to around connection 204, it errors out. After this change though, each new POST should not show any new connection.
#### Any background context you want to provide?

@desmondmorris All those Mobile Common errors about connections getting refused - I'm pretty sure it's this.
#### What are the relevant tickets?

Fixes DoSomething#74
