### PR TITLE
End level player evaluation

### DIFF
--- a/app/config/competitive-stories.json
+++ b/app/config/competitive-stories.json
@@ -13,6 +13,7 @@
           {
             "next": 168455,
             "valid_answers": [
+              "L11A",
               "A",
               "LOOK"
             ]
@@ -20,6 +21,7 @@
           {
             "next": 168457,
             "valid_answers": [
+              "L11B",
               "B",
               "DOOR"
             ]
@@ -97,13 +99,13 @@
         "__comments": "Level 1-3A",
         "choices": [
           {
-            "next": "END-Level1",
+            "next": "END-LEVEL1",
             "valid_answers": [
               "L14A"
             ]
           },
           {
-            "next": "END-Level1",
+            "next": "END-LEVEL1",
             "valid_answers": [
               "L14B"
             ]
@@ -114,36 +116,36 @@
         "__comments": "Level 1-3B",
         "choices": [
           {
-            "next": "END-Level1",
+            "next": "END-LEVEL1",
             "valid_answers": [
               "L14A"
             ]
           },
           {
-            "next": "END-Level1",
+            "next": "END-LEVEL1",
             "valid_answers": [
               "L14C"
             ]
           }
         ]
       },
-      "END-Level1": {
-        "__comments": "This is all TBD. I'm not exactly sure how I'm dealing with end-level scenarios yet.",
+      "END-LEVEL1": {
+        "__comments": "This is all TBD. I'm not exactly sure how I'm dealing with end-level scenarios yet. Maybe use opt-in paths instead of the string answers here.",
         "choices": [
           {
-            "next": "@TODO: oip for L1 result A",
+            "next": "168825",
             "conditions": {
               "$or": ["L12B", "L12C"]
             }
           },
           {
-            "next": "@TODO: oip for L1 result B",
+            "next": "168827",
             "conditions": {
               "$and": ["L12A", {"$or": ["L14B", "L14C"]}]
             }
           },
           {
-            "next": "@TODO: oip for L1 result C",
+            "next": "168831",
             "conditions": {
               "$and": ["L12A", "L14A"]
             }


### PR DESCRIPTION
#### What's this PR do?

The message delivered at the end of levels is determined by some combination of user choices up to that point in the story. This handles those end level scenarios and evaluates the message that should be delivered.
#### Where should the reviewer start?

`getEndLevelMessage` is the main new thing happening here.

That function will determine what the next opt-in path for the user will be. This is dictated by the choices configured in `"END-LEVEL1": {"choices":"conditions": []}` which are structured like mongo logic operations. `getEndLevelMessage` essentially parses through the logic to select the proper path.
#### What are the relevant tickets?

https://github.com/DoSomething/ds-mdata-responder/issues/70

cc: @DeeZone @desmondmorris
