### PR TITLE
Smarter answer validation 

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -397,7 +397,7 @@ SGCompetitiveStoryController.prototype.userAction = function(request, response) 
           // array we might only have listed 'A'. We still want 'A)' to be valid.
           var allowableChars = '[s\\.\\,\\?\\*\\)\\}\\]]*';
           var validAnswer = choice.valid_answers[j];
-          var regex = new RegExp('^' + validAnswer + allowableChars + '$');
+          var regex = new RegExp('^' + validAnswer + allowableChars + '$', 'i');
           if (userFirstWord.match(regex)) {
             choiceIndex = i;
             break;


### PR DESCRIPTION
#### What's this PR do?

Uses regex to be a little more flexible with validating correct answers. For example, we want to allow an answer of 'A)' or 'A.' even if our `valid_answers` array in the config file only has 'A'.
#### What are the relevant tickets?

Issue DS-174
