### PR TITLE
Fix for 'OK' messages being sent to users going through SMS game flow

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -149,7 +149,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     self.scheduleMobileCommonsOptIn(optinArgs);
   });
 
-  response.send(200);
+  response.send();
 
   // Log the create game request to stathat
   this.app.stathatReportCount('mobilecommons: create game request: success', 1);
@@ -239,7 +239,7 @@ SGCompetitiveStoryController.prototype.betaJoinGame = function(request, response
         };
 
         obj.scheduleMobileCommonsOptIn(args);
-        obj.response.send(200);
+        obj.response.send();
         return;
       }
 
@@ -265,7 +265,7 @@ SGCompetitiveStoryController.prototype.betaJoinGame = function(request, response
       if (allJoined) {
         doc.game_started = true;
         doc = obj.startGame(obj.gameConfig, doc);
-        obj.response.send(200);
+        obj.response.send();
       }
       // If we're still waiting on people, send appropriate messages to the recently
       // joined beta and alpha users.
@@ -273,7 +273,7 @@ SGCompetitiveStoryController.prototype.betaJoinGame = function(request, response
         console.log('Waiting on ' + numWaitingOn + ' people to join.');
 
         doc = obj.sendWaitMessages(obj.gameConfig, doc, obj.joiningBetaPhone);
-        obj.response.send(200);
+        obj.response.send();
       }
 
       // Save the doc in the database with the betas and current status updates.
@@ -333,7 +333,7 @@ SGCompetitiveStoryController.prototype.alphaStartGame = function(request, respon
       // Start the game.
       doc.game_started = true;
       doc = obj.startGame(obj.gameConfig, doc);
-      obj.response.send(200);
+      obj.response.send();
 
       // Save the doc in the database with the current status updates.
       obj.gameModel.update(
@@ -563,7 +563,7 @@ SGCompetitiveStoryController.prototype.userAction = function(request, response) 
 
       obj.scheduleMobileCommonsOptIn(optinArgs);
 
-      obj.response.send(200);
+      obj.response.send();
     }
     else {
       obj.response.send(500, 'Story configuration invalid.');


### PR DESCRIPTION
#### What's this PR do?

This removes the 200 status code that the app responds with when successfully progressing through an SMS game.

With the 200 code, users would get the 'OK' message on their phones in addition to the opt-in message that we're subscribing them to. Not specifying a status code seems fine, and still serves the purpose of acknowledging receipt of the request.
#### What are the relevant tickets?

https://github.com/jonuy/ds-mdata-responder/issues/2
