### PR TITLE
stathatReport scoping fix

### DIFF
--- a/app/controllers/Tips.js
+++ b/app/controllers/Tips.js
@@ -53,10 +53,14 @@ Tips.prototype.deliverTips = function(request, response, mdataOverride) {
 
   var tipModel = this.tipModel;
 
+
+  var self = this; //fixes scoping issue, 'this' changes in callback of MongoDB query
+
   // Find an existing document for a user with the requesting phone number
   tipModel.findOne(
     {phone: request.body.phone},
     function(err, doc) {
+
       if (err) return console.log(err);
 
       // An existing doc for this phone number has been found
@@ -110,7 +114,7 @@ Tips.prototype.deliverTips = function(request, response, mdataOverride) {
         if (request.body.dev !== '1') {
           mobilecommons.optin(args);
 
-          this.app.stathatReport('Count', 'mobilecommons: tips request: success', 1);
+          self.app.stathatReport('Count', 'mobilecommons: tips request: success', 1);
         }
 
         // Update the existing doc in the database
@@ -143,7 +147,7 @@ Tips.prototype.deliverTips = function(request, response, mdataOverride) {
         if (request.body.dev !== '1') {
           mobilecommons.optin(args);
 
-          this.app.stathatReport('Count', 'mobilecommons: tips request: success', 1);
+          self.app.stathatReport('Count', 'mobilecommons: tips request: success', 1);
         }
 
         // Create a new doc


### PR DESCRIPTION
#### What's this PR do?

Within Tips.js, this.app was undefined and the this.app.stathatReport function was breaking. Found out that this was because of 'this' scoping issues within the Mongoose query callback. Fixed by assigning self = this. 
#### How should this be manually tested?

Post to ds/tips and verify that this works. 
#### What are the relevant tickets?

Fixes #116
