### PR TITLE
one of two users selecting impact choice now delivers non-impact end-lev...

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -1001,6 +1001,7 @@ SGCompetitiveStoryController.prototype.getEndLevelGroupMessage = function(endLev
       var conditions = storyItem.choices[j].conditions;
       if (evaluateCondition(conditions, phone, gameDoc, 'answer')) {
         choiceCounter[j]++;
+        break;
       }
     }
   }
@@ -1009,12 +1010,18 @@ SGCompetitiveStoryController.prototype.getEndLevelGroupMessage = function(endLev
   var selectChoice = -1;
   var maxCount = -1;
   for (var i = 0; i < choiceCounter.length; i++) {
-    if (choiceCounter[i] > maxCount) {
+    /* Covers edge case --> if only 1 out of 2 users select the impact choice-set, 
+    the group will now receive the non-impact level ending message.
+    (This is purely because the non-impact choice-set is always second in the array of choices.) */
+
+    var isTwoPlayerGame = (gameDoc.players_current_status.length === 2);
+    var countEqualsMax = (choiceCounter[i] === maxCount);
+    var isNewMax = (choiceCounter[i] > maxCount);
+    if ((isTwoPlayerGame && countEqualsMax) || isNewMax){
       selectChoice = i;
       maxCount = choiceCounter[i];
     }
   }
-
   return storyItem.choices[selectChoice].next;
 };
 


### PR DESCRIPTION
#### What's this PR do?

Squashes two bugs: one of two users selecting the impact choice now delivers the non-impact end-level condition, each users choice set now only counted once when determining winning level choice-set. 

(Two out of four users selecting the impact choice still delivers the impact end-level condition, however.) 
#### How should this be manually tested?

Postman! Create a game, have two users join, have one select the impact choice-set, one select a non-impact choice-set. 

(Was also tested with four players.) 
#### What are the relevant tickets?

Jira SMS-60
