### PR TITLE
Updated Bully Text end-game paths

### DIFF
--- a/app/config/competitive-stories.json
+++ b/app/config/competitive-stories.json
@@ -896,31 +896,27 @@
         "__comments": "Bully Text end-game superlatives",
         "choices": [
           {
-            "next": 169969,
+            "next": 170437,
             "conditions": { "$and": ["L12D", "L22C", "L31A", "L41B", "L51A", "L62C"] }
           },
           {
-            "next": 169971,
+            "next": 170445,
             "conditions": { "$and": ["L12C", "L22C", "L41B"] }
           },
           {
-            "next": 169973,
+            "next": 170447,
             "conditions": { "$and": ["L22D", "L31A", "L42D", "L51B"] }
           },
           {
-            "next": 169975,
+            "next": 170449,
             "conditions": { "$and": ["L11B", "L52C", "L61A"] }
           },
           {
-            "next": 169977,
+            "next": 170451,
             "conditions": { "$and": ["L12D", "L51B", {"$or": ["L41A", "L42C"]}] }
           },
           {
-            "next": 169983,
-            "conditions": { "$and": ["L32D"] }
-          },
-          {
-            "next": 169985,
+            "next": 170453,
             "conditions": { "$or": ["L61A", "L61B", "L62C", "L62D"] }
           }
         ]


### PR DESCRIPTION
#### What's this PR do?

Updated the end-game opt-in paths and removes the one condition that got people the Biggest Bookworm superlative. No one wants to be a bookworm.
#### How should this be manually tested?

No logic's changed here, so it's probably just sufficient to verify that these new links are active opt-in paths:
- https://secure.mcommons.com/campaigns/128277/opt_in_paths/170437
- https://secure.mcommons.com/campaigns/128285/opt_in_paths/170445
- https://secure.mcommons.com/campaigns/128287/opt_in_paths/170447
- https://secure.mcommons.com/campaigns/128289/opt_in_paths/170449
- https://secure.mcommons.com/campaigns/128291/opt_in_paths/170451
- https://secure.mcommons.com/campaigns/128293/opt_in_paths/170453
#### Any background context you want to provide?

The paths are being updated because each individual end-game path is now in its own Mobile Commons campaign. This is so that follow up scheduled messages can be sent to players that is specific to the result they got at the end of the game.

cc: @tongxiang 
