### PR TITLE
Allow for games to be created with less than 3 invited betas

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -96,7 +96,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
   // If number of betas invited doesn't meet the minimum number, then error.
   if (gameDoc.betas.length < MIN_PLAYERS_TO_INVITE) {
     response.send(406, 'Not enough players. You need to invite at least %d to start.', MIN_PLAYERS_TO_INVITE);
-    return null;
+    return false;
   }
 
   // Save game to the database.

--- a/app/controllers/SGCreateFromMobileController.js
+++ b/app/controllers/SGCreateFromMobileController.js
@@ -254,12 +254,12 @@ SGCreateFromMobileController.prototype._updateDocument = function(configDoc) {
 SGCreateFromMobileController.prototype._removeDocument = function(phone) {
   this.configModel.remove(
     {alpha_mobile: phone},
-    function(err, num, raw) {
+    function(err, num) {
       if (err) {
         console.log(err);
       }
       else {
-        console.log(raw);
+        console.log('Number of create config documents removed: ' + num);
       }
     }
   );


### PR DESCRIPTION
#### What's this PR do?

This allows for a game to be created with less than 3 betas being invited. This is to support games being created from mobile. See https://github.com/DoSomething/ds-mdata-responder/pull/122.
#### Where should the reviewer start?

MAX_PLAYERS_TO_INVITE and MIN_PLAYERS_TO_INVITE are intended to be const values to set the max number of players that can be invited to a game and the minimum required to start/create one. This also serves the purpose of bringing transparency to what would otherwise be "magic numbers" hidden in code.

The `for` loop on line 80 adds betas into the game document. This would previously error out if an invalid phone number were found. Now it just adds any valid ones it finds. It'll error out after the `for` loop if the number of betas is less than the minimum required.
#### How should this be manually tested?

If you'd like to manually test, this is what I did:
1. Start creating a game from mobile:  
   **POST** to `/sms-multiplayer-game/mobile-create?story_type=competitive-story&story_id=100`  
   with params: `phone=15555550100` and `args=5555550101`
2. Skip adding more betas and just create:  
   **POST** to `/sms-multiplayer-game/mobile-create?story_type=competitive-story&story_id=100`  
   with params: `phone=15555550100` and `args=Y`
3. At this point you should see a new document created in the `sg_competitivestory_games` collection with only a single beta having been invited.
#### What are the relevant tickets?

SMS-26

cc: @DeeZone @tongxiang 
