### PR TITLE
Added profile_update wrapper function for Mobile Commons API

### DIFF
--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -7,6 +7,46 @@ var request = require('request')
     ;
 
 /**
+ * Mobile Commons profile_update API. Can be used to subscribe the user to an
+ * opt-in path.
+ *
+ * @param phone
+ *   Phone number of the profile to update.
+ * @param optInPathId
+ *   Opt-in path to subscribe the user to.
+ * @param customFields
+ *   Array of custom profile field names and values to update the user with.
+ */
+exports.profile_update = function(phone, optInPathId, customFields) {
+  var url = 'https://secure.mcommons.com/api/profile_update';
+  var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
+  var authPass = process.env.MOBILECOMMONS_AUTH_PASS;
+
+  var postData = {
+    auth: {
+      user: authEmail,
+      pass: authPass
+    },
+    form:{
+      phone_number: phone,
+      opt_in_path_id: optInPathId
+    }
+  };
+
+  var customFieldKeys = Object.keys(customFields);
+  for (var i = 0; i < customFieldKeys.length; i++) {
+    var key = customFieldKeys[i];
+    postData.form[key] = customFields[key];
+  }
+
+  request.post(url, postData, function (error, response, body) {
+    if (error) {
+      console.log(error);
+    }
+  });
+};
+
+/**
  * Opt-in mobile numbers into specified Mobile Commons paths.
  */
 exports.optin = function(args) {

--- a/mobilecommons/package.json
+++ b/mobilecommons/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ds-mobilecommons",
+  "main": "./mobilecommons.js"
+}


### PR DESCRIPTION
#### What's this PR do?

Adds function to do a profile update with Mobile Commons' API. This can be used to both subscribe a user to an opt-in path and to update fields on a user's profile. This will be particularly useful for populating fields used to display info in templated messages in the donation flow.
#### Any background context?

See https://mobilecommons.zendesk.com/hc/en-us/articles/202052534-REST-API#ProfileUpdate
