### PR TITLE
add clarifying game create / start message

### DIFF
--- a/app/config/competitive-stories.json
+++ b/app/config/competitive-stories.json
@@ -427,7 +427,8 @@
       "ask_beta_1_oip": 170433,
       "ask_beta_2_oip": 170435,
       "invalid_mobile_oip": 170439,
-      "not_enough_players_oip": 170465
+      "not_enough_players_oip": 170465,
+      "remind_friends_to_join_to_start_game_oip": 171109
     },
     "story": {
       "169859": {

--- a/app/controllers/SGCreateFromMobileController.js
+++ b/app/controllers/SGCreateFromMobileController.js
@@ -94,7 +94,6 @@ function ErrorAbortPromiseChain() {
  *   Express response object.
  */
 SGCreateFromMobileController.prototype.processRequest = function(request, response) {
-
   if (typeof request.query.story_id === 'undefined'
       || typeof request.query.story_type === 'undefined'
       || typeof request.body.phone === 'undefined'
@@ -143,9 +142,12 @@ SGCreateFromMobileController.prototype.processRequest = function(request, respon
     // If a document is found, then process the user message.
     else {
       var message = self.request.body.args;
-      // Create the game if we have at least one beta number
+      // Create the game if we have at least one beta number.
+      // If the alpha responds 'Y' to the 'create game now?' query. 
       if (messageHelper.isYesResponse(message)) {
         if (configDoc.beta_mobile_0 && messageHelper.isValidPhone(configDoc.beta_mobile_0)) {
+          // Reminds alpha that we've merely created the game; her friends need to join for it to start.
+          sendSMS(configDoc.alpha_mobile, self.storyConfig.mobile_create.remind_friends_to_join_to_start_game_oip);
           createGame(configDoc, self.host);
           self._removeDocument(configDoc.alpha_mobile);
         }

--- a/app/models/sgCollaborativeStory.js
+++ b/app/models/sgCollaborativeStory.js
@@ -8,7 +8,7 @@ var sgCollaborativeStory = function(app) {
   var modelName = 'sg_collaborativestory_game';
 
   var schema = sgGameSchema;
-  // @TODO figure out how this schema's going to differ from the collaborative story
+  // @TODO figure out how this schema's going to differ from the competitive story
   schema.add({
     // Last Mobile Commons opt in path delivered to the alpha player
     alpha_current_opt_in_path: Number,

--- a/app/router.js
+++ b/app/router.js
@@ -76,7 +76,7 @@ module.exports = function(app) {
    * Guides users through creating an SMS multiplayer game from mobile.
    */
   app.post('/sms-multiplayer-game/mobile-create', function(request, response) {
-    var host = request.get('host');
+    var host = request.get('host'); // Retrieving hostname; Express parsing request.
     var controller = new SGCreateFromMobileController(app, host);
     controller.processRequest(request, response);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ds-mdata-responder",
-  "version": "0.0.1",
+  "version": "0.0.1-19",
   "description": "Interface for interacting with DoSomething.org SMS experiences.",
   "dependencies": {
     "connect-multiparty": "1.1.0",


### PR DESCRIPTION
#### What's this PR do?

Adds a new opt in path for a potentially confusing situation: the user when creating a game, is prompted to add beta players. When the user adds a beta, the alpha is then asked if she wants to create the game witout adding more betas. 

This is confusing, because the user may think that answering 'Y' to this query is in fact **starting** the game, when in fact she's only **creating it** and more users need to join. 

This is simply adding a new opt in path which clarifies the situation to the user. The user is opted into this path after they answer 'Y' to the message asking if they want to create the game now. 
#### How should this be manually tested?

Via mobile phone. 
