### PR TITLE
SMS-70 Adding New Relic monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 #npm
 node_modules
 
+# newrelic
+newrelic_agent.log

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,24 @@
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config.defaults.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name : ['ds-mdata-responder'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key : process.env.NEWRELIC_LICENSE_KEY,
+  logging : {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level : 'trace'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "mocha": "1.20.x",
     "mongoose": "~3.8.8",
     "mysql": "2.1.x",
+    "newrelic": "1.11.x",
     "path": "~0.4.9",
     "q": "^1.0.1",
     "request": "2.34.x",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,8 @@
+// Nodejitsu specifies NODE_ENV='production' by default
+if (process.env.NODE_ENV == 'production') {
+  require('newrelic');
+}
+
 var application_root = __dirname
     , express = require('express')
     , path = require('path');


### PR DESCRIPTION
#### What's this PR do?

Adds New Relic monitoring to our app in production. I've also just added the NEWRELIC_LICENSE_KEY environment variable to our Nodejitsu env.
#### Any background context?
- Raised priority on getting this done sooner so that we can try to better debug errors we're seeing on production.
- Basically just followed this to hook it up: http://newrelic.com/nodejs
#### What are the relevant tickets?

SMS-70

cc: @mshmsh5000 Just a heads up that this app should start showing up in New Relic too.
