### PR TITLE
incorporate Bitly link shortening in donation transaction

### DIFF
--- a/app/lib/bitly/bitly.js
+++ b/app/lib/bitly/bitly.js
@@ -5,6 +5,8 @@
  *
  * @param longURL
  *   the URL to be shortened 
+ * @param callback
+ *   the callback function to be called, taking a single param of the shortened URL
  * @return shortURL
  *   a shortened form of the long URL
  */
@@ -37,7 +39,7 @@ function shortenLink(longURL, callback) {
       }
     }
     else {
-      console.log('error: ', err)
+      console.log('error: ', err);
     }
   });
 }

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -288,7 +288,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
             shortenLink(jsonBody.proposalURL, function(shortenedLink) {
               var customFields = {
                 donorsChooseProposalUrl: shortenedLink
-              }
+              };
               mobilecommons.profile_update(donorInfoObject.donorPhoneNumber, donationConfig.donate_complete, customFields);
             })
           }


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new service in the `app/lib` directory: `bitly`, which exports a **.shortenLink()** function that calls the Bitly API in order to shorten the long DonorsChoose URL returned with the success callback. 

Once the shortened URL is retrieved, we ping the MobileCommons API to add this shortened URL to the MC user profile. The final "your donation has been successful" text to the user thus contains the shortened URL, which then displays the proposal web page including the user's first name and transaction. 
#### Where should the reviewer start?

Check out the `bitly.js` file to start off with, to understand how the simple API call function works. Then check out how we've integrated it in the `DonorsChooseDonationController.js`, where we've included it in the **.submitDonation()** function. 
#### How should this be manually tested?

Run this locally, and use Postman to walk through the donations flow. If all goes well, the last text you should receive should contain updates on the project from a shortened "http://dsorg.us" URL. 
#### What are the relevant tickets?

JIRA SMS-84 and redundantly, JIRA SMS-38 (goodbye JIRA!!!)
