### PR TITLE
add character limits to schoolname and city/location

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -14,10 +14,10 @@
  *        submitDonation responsible for responding to user with success message
  */
 
-var donorsChooseApiKey = (process.env.DONORSCHOOSE_API_KEY || null),
-    donorsChooseApiPassword = (process.env.DONORSCHOOSE_API_PASSWORD || null),
-    donorsChooseApiBaseUrl = 'https://apisecure.donorschoose.org/common/json_api.html?APIKey=',
-    defaultDonorsChooseTransactionEmail = (process.env.DONORSCHOOSE_DEFAULT_EMAIL || null);
+var donorsChooseApiKey = (process.env.DONORSCHOOSE_API_KEY || null)
+  , donorsChooseApiPassword = (process.env.DONORSCHOOSE_API_PASSWORD || null)
+  , donorsChooseApiBaseUrl = 'https://apisecure.donorschoose.org/common/json_api.html?APIKey='
+  , defaultDonorsChooseTransactionEmail = (process.env.DONORSCHOOSE_DEFAULT_EMAIL || null);
 
 if (process.env.NODE_ENV == 'test') {
   donorsChooseApiKey = 'DONORSCHOOSE';
@@ -25,9 +25,10 @@ if (process.env.NODE_ENV == 'test') {
   donorsChooseApiBaseUrl = 'https://apiqasecure.donorschoose.org/common/json_api.html?APIKey=';
 }
 
-var TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR = 'zip'; // 'zip' or 'state'. Our retrieveLocation() function will adjust accordingly.
-var DONATION_AMOUNT = 1;
-var DONATE_API_URL = donorsChooseApiBaseUrl + donorsChooseApiKey;
+var TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR = 'zip' // 'zip' or 'state'. Our retrieveLocation() function will adjust accordingly.
+  , DONATION_AMOUNT = 1
+  , DONATE_API_URL = donorsChooseApiBaseUrl + donorsChooseApiKey
+  , CITY_SCHOOLNAME_CHARLIMIT = 79; // Limit for the number of characters we have in this OIP: https://secure.mcommons.com/campaigns/128427/opt_in_paths/170623
 
 var mobilecommons = require('../../../../mobilecommons/mobilecommons')
   , messageHelper = require('../../userMessageHelpers')
@@ -116,13 +117,24 @@ DonorsChooseDonationController.prototype.findProject = function(request, respons
         }
       }
 
+      var revisedLocation = selectedProposal.city;
+      var revisedSchoolName = selectedProposal.schoolName;
+
+      // Check to see if we exceed character limits this text message: 
+      // https://secure.mcommons.com/campaigns/128427/opt_in_paths/170623
+      if ((selectedProposal.city + selectedProposal.schoolName).length > CITY_SCHOOLNAME_CHARLIMIT) {
+        revisedLocation = selectedProposal.state; // subsitute the state abbreviation
+        if ((revisedLocation + selectedProposal.schoolName).length > CITY_SCHOOLNAME_CHARLIMIT) {
+          revisedSchoolName = selectedProposal.schoolName.slice(0, parseInt(CITY_SCHOOLNAME_CHARLIMIT)-2);
+        }
+      }
+
       var mobileCommonsCustomFields = {
         donorsChooseProposalId :          selectedProposal.id,
         donorsChooseProposalTitle :       selectedProposal.title,
-        donorsChooseProposalUrl :         selectedProposal.proposalURL, // Currently used in MobileCommons.
         donorsChooseProposalTeacherName : selectedProposal.teacherName, // Currently used in MobileCommons.
-        donorsChooseProposalSchoolName :  selectedProposal.schoolName, // Currently used in MobileCommons. 
-        donorsChooseProposalSchoolCity :  selectedProposal.city, // Currently used in MobileCommons.
+        donorsChooseProposalSchoolName :  revisedSchoolName, // Currently used in MobileCommons. 
+        donorsChooseProposalSchoolCity :  revisedLocation, // Currently used in MobileCommons.
         donorsChooseProposalSummary :     selectedProposal.fulfillmentTrailer,
       }
 


### PR DESCRIPTION
#### What's this PR do?

This adds a character limit of **CITY_SCHOOLNAME_CHARLIMIT** (currently set to 79 characters) to the combined sum of the location and schoolName properties of the donors choose proposal returned. 

This prevents the text message the user is opted into which contains this data from being longer than 160 characters. 

Additionally, there have been some formatting changes to the variables declared at the top of the `DonorsChooseDonationController.` 
#### Where should the reviewer start?

Line 120 of the `DonorsChooseDonationsController.js`. 
#### How should this be manually tested?

Simple string manipulation, has been tested with a fake **selectedProposal** object. Can be tested again by using [this REPL tool](http://repl.it/0wk) (code saved.) 
#### What are the relevant tickets?

JIRA SMS-99
