### PR TITLE
add additional transaction error handling

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -303,6 +303,9 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
               };
               mobilecommons.profile_update(donorInfoObject.donorPhoneNumber, donationConfig.donate_complete, customFields);
             })
+          } else {
+            console.log('Donation to proposal ' + proposalId + ' was NOT successful. Body: ', body);
+            sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
           }
         }
         catch (e) {


### PR DESCRIPTION
#### What's this PR do?

This adds additional error handling. If the donorschoose.org API returns a valid response, but was unable to complete the transaction (which could be due to any number of things, including user error), we'll send the user an error message and ask them to run through the donations route again. 
#### Where should the reviewer start?

Hmmm--which of the three lines of code should you start with?
#### How should this be manually tested?

Postman! 
