### PR TITLE
Decrease # of setTimeout calls and simplify closure data in each

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -1339,13 +1339,13 @@ SGCompetitiveStoryController.prototype._endGameFromPlayerExit = function(playerD
 /**
  * The following two functions are for handling Mongoose Promise chain errors.
  */
-function promiseErrorCallback(tag, message) {
-  return onPromiseErrorCallback.bind({tag: tag, message: message});
+function promiseErrorCallback(message) {
+  return onPromiseErrorCallback.bind({message: message});
 }
 
 function onPromiseErrorCallback(err) {
   if (err) {
-    console.error('[' + this.tag + '] ' + this.message + '\n', err);
+    console.error('Error: ' + this.message + '\n', err.stack);
   }
 }
 
@@ -1379,7 +1379,7 @@ function scheduleSoloMessage(gameId, gameModel, oip) {
         };
         scheduleMobileCommonsOptIn(args);
       }
-    }, promiseErrorCallback('scheduleSoloMessage.checkIfBetaJoined', 'Unable to find game.'));
+    }, promiseErrorCallback('Unable to find game.'));
   };
 
   setTimeout(function(){ checkIfBetaJoined(gameId, gameModel, oip) }, TIME_UNTIL_SOLO_MESSAGE_SENT);


### PR DESCRIPTION
#### What's this PR do?

In an effort to resolve the gradual memory increase we're seeing in the app, we're starting by trying to cleanup our use of `setTimeout` calls.
#### Where should the reviewer start?
- With `scheduleMobileCommonsOptIn()`, we're decreasing the number of setTimeout calls by just calling the `optin` method if `delay` is either undefined or 0.
- The logic to send a solo play message has been moved into `scheduleSoloMessage()`. Instead of passing in the entire context of the SGCompetitveStoryController object to be tracked in the closure, the callback only needs the game id, a reference to the game model, and the opt-in path. I'm not entirely sure if this is gonna show marked improvement, but it does at least simplify the data needed within the closure.
#### How should this be manually tested?

Successful test cases I manually went through:
- Creating game and receiving the solo-play message
- Creating game, having a beta join, and not receiving the solo-play message
- Creating game, having a beta join, and playing through the first level

Feel free to try those or any others you might think are worth trying
#### Any background context?

This is in response to some of the sporadic 502 errors the app is throwing. The hunch is that memory isn't getting properly cleaned up somewhere, and our first attempt is with these setTimeouts.
