### PR TITLE
_endGameFromInvite fixes

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -4,7 +4,7 @@
 
 var mobilecommons = require('../../mobilecommons/mobilecommons')
   , messageHelper = require('../lib/userMessageHelpers')
-  , emitter = require('../eventEmitter');
+  , emitter = require('../eventEmitter')
   ;
 
 // Delay (in milliseconds) for end level group messages to be sent.
@@ -152,13 +152,9 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
   }).then(function(playerDocs) {
 
     // End games that these players were previously in.
-    // @todo _endGameFromPlayerExit() should return a promise and we'll need to
-    // chain the following code to run after the promise.
     self._endGameFromPlayerExit(playerDocs);
 
     // Upsert the document for the alpha user.
-
-    // @todo ** THIS COULD HAPPEN FIRST, BEFORE _endGameFromPlayerExit **
     self.userModel.update(
       {phone: self.createdGameDoc.alpha_phone},
       {$set: {phone: self.createdGameDoc.alpha_phone, current_game_id: self.createdGameDoc._id}},


### PR DESCRIPTION
#### What's this PR do?

Fixes:
- Players not receiving the "your game has ended" message
- Incorrectly ending games where the player being pulled out of a group never actually joined the ended game
#### Where should the reviewer start?
- `players[playerIdx]` on line 1355 fixes the first issue.
- The `skipGame` logic fixes the second issue.
#### How should this be manually tested?

I manually tested the following scenarios:
- **Scenario 1**
  - Creating a game with player A, B1, B2, and B3
  - B1 joins. A starts the game
  - B2 creates a new game
  - Verified A and B1 are NOT pulled out of their game
- **Scenario 2**
  - Creating a game with player A, B1, B2, and B3
  - B1 and B2 join. A starts the game
  - B3 creates a new game and invites B1
  - Verified A and B2 get the "your game has ended" message
#### Any background context?

This should resolve at least some of the 404 errors the app's been throwing.
