### PR TITLE
Issue214

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -1062,7 +1062,6 @@ SGCompetitiveStoryController.prototype.getIndivRankEndGameMessage = function(pho
     for (var i = 0; i < gameDoc.players_current_status.length; i++) {
       tempPlayerSuccessObject[gameDoc.players_current_status[i].phone] = 0;
     }
-    console.log('tempPlayerSuccessObject before rankings applied', tempPlayerSuccessObject);
 
     // Counts the number of levels each user has successfully passed.
     for (var i = 0; i < indivLevelSuccessOips.length; i++) {
@@ -1112,7 +1111,7 @@ SGCompetitiveStoryController.prototype.getIndivRankEndGameMessage = function(pho
       }
       for (var j = 0; j < nextRank.length; j++) {
         for (var k = 0; k < gameDoc.players_current_status.length; k++) {
-          if (nextRank[j] && (gameDoc.players_current_status[k].phone == nextRank[j].phone)) {
+          if (gameDoc.players_current_status[k].phone == nextRank[j].phone) {
             // We only record and signify ties for first and second place.
             if (nextRank.length > 1 && (i === 1||i === 2)) {
               gameDoc.players_current_status[k].rank = i + '-tied';


### PR DESCRIPTION
#### What's this PR do?

Previously, our app was crashing because of the error below. (The alignment may be off here, but the nextRank[j].phone was throwing "Cannot read property 'phone' of undefined.) 

```
[10/14 13:25:25 EDT][err]           if (gameDoc.players_current_status[k].phone == nextRank[j].phone) {
[10/14 13:25:25 EDT][err]                                                                     ^
[10/14 13:25:25 EDT][err] TypeError: Cannot read property 'phone' of undefined
[10/14 13:25:25 EDT][err]     at SGCompetitiveStoryController.getIndivRankEndGameMessage (/opt/run/snapshot/package/app/controllers/SGCompetitiveStoryController.js:1154:69)
[10/14 13:25:25 EDT][err]     at SGCompetitiveStoryController.getUniqueIndivEndGameMessage (/opt/run/snapshot/package/app/controllers/SGCompetitiveStoryController.js:1078:17)
[10/14 13:25:25 EDT][err]     at execUserAction (/opt/run/snapshot/package/app/controllers/SGCompetitiveStoryController.js:644:30)
[10/14 13:25:25 EDT][err]     at Promise.onGameFound (/opt/run/snapshot/package/app/controllers/SGCompetitiveStoryController.js:739:7)
[10/14 13:25:25 EDT][err]     at Promise.<anonymous> (/opt/run/snapshot/package/node_modules/mongoose/node_modules/mpromise/lib/promise.js:177:8)
[10/14 13:25:25 EDT][err]     at Promise.emit (events.js:95:17)
[10/14 13:25:25 EDT][err]     at Promise.emit (/opt/run/snapshot/package/node_modules/mongoose/node_modules/mpromise/lib/promise.js:84:38)
[10/14 13:25:25 EDT][err]     at Promise.fulfill (/opt/run/snapshot/package/node_modules/mongoose/node_modules/mpromise/lib/promise.js:97:20)
[10/14 13:25:25 EDT][err]     at /opt/run/snapshot/package/node_modules/mongoose/lib/query.js:1394:13
[10/14 13:25:25 EDT][err]     at model.Document.init (/opt/run/snapshot/package/node_modules/mongoose/lib/document.js:250:11)
[10/14 13:25:25 EDT][err] /opt/run/snapshot/package/app/controllers/SGCompetitiveStoryController.js:1154
```

If **none** of the players selected **any** of the success opt in paths, the `tempPlayerSuccessObject` remained empty. This meant that the `playerRankArray` remained empty, and thus the `nextRank` object was getting populated by an "undefined object". 

With the magnanimous oversight of Jonathan Uy, we solved this problem. 1) We added a loop which populated the `tempPlayerSuccessObject` with an object pre-assigning a 0 number of successes to each user. 

This fix also solved another problem, which we weren't aware of before. Under our previous system, **any** players who didn't select any success paths would not receive a ranking. (Even if another player **had** selected a success path, which would have prevented the app from crashing.) Now, with this fix, **all** players will receive a raning. 
#### How should this be manually tested?

To play the game through with paths producing **no** success paths, the following user action answer combination produces no successes: 

```
AA
BB
BA
BB
AA
AA
```

I've also pulled out only the relevant end-game code, to get a better view of the problem. [Here's](https://gist.github.com/tongxiang/cdd6bd7fb30c2c4e6b9a) a Gist which represents a completed gameDoc between two players, with neither of them selecting any success opt in paths. 

To see the code crashing, [here is a repl.it](http://repl.it/1g6/6) showing the failure case using the gameDoc above. (I've extracted the function `getIndivRankEndGameMessage`.

Alternatively, [here is a repl.it](http://repl.it/1g6/3) (with console.logs added for illustrativeness) showing the modified fixed code. 
