### PR TITLE
Fix to prevent betas from joining ended games

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -348,7 +348,7 @@ SGCompetitiveStoryController.prototype.betaJoinGame = function(request, response
     var execBetaJoinGame = function(obj, doc) {
 
       // If the game's already started, notify the user and exit.
-      if (doc.game_started) {
+      if (doc.game_started || doc.game_ended) {
         // Good place to notify betas about ALPHA SOLO keywords for opt-in-paths. 
         optinSingleUser(obj.request.body.phone, obj.gameConfig[doc.story_id].game_in_progress_oip);
         obj.response.send();
@@ -1251,7 +1251,12 @@ SGCompetitiveStoryController.prototype._endGameFromPlayerExit = function(playerD
       else {
         var noActivePlayerInGame = true;
         for (var j = 0; j < playerDocs.length; j++) {
-          if (playerDocs[i].current_game_id.equals(gameDoc._id) == false) {
+          if (playerDocs[j].current_game_id.equals(gameDoc._id) == false) {
+            continue;
+          }
+
+          if (playerDocs[j].phone == gameDoc.alpha_phone) {
+            noActivePlayerInGame = false;
             continue;
           }
 


### PR DESCRIPTION
#### What's this PR do?

Previously betas could enter a game after the alpha's decided to play solo instead. This would break the game flow and cause bugs for the users as they tried to progress through the game again.
#### How should this be manually tested?

There's probably a handful of bugs that this caused, but the one scenario that we saw reported and the one that I tested:
1. Alpha creates a game A inviting 3 other betas
2. Alpha decides to play solo, effectively creating a game B and closing game A
3. Beta accepts the invite and tries to join.

Result: Alpha continues to play solo uninterrupted. Beta receives the "unable to join game in progress" message.
#### What are the relevant tickets?

Fixes #226 
