### PR TITLE
Providing a different URI to be used for logging

### DIFF
--- a/app/lib/logger/logger.js
+++ b/app/lib/logger/logger.js
@@ -3,7 +3,7 @@ var winston = require('winston')
 
 require('winston-mongodb').MongoDB;
 
-var mongoDbUri = process.env.DB_URI || 'mongodb://localhost/ds-mdata-responder';
+var mongoDbUri = process.env.LOGGING_DB_URI || 'mongodb://localhost/ds-mdata-responder';
 var logger = new (winston.Logger) ({
   levels: {
     verbose: 0,


### PR DESCRIPTION
#### What's this PR do?

Allows a different database URI to be used for logging. This variable is now setup on the production environment and with this deploy, it should fix winston logging to the MongoDB.
#### Any background context?

A little more info on the bug itself - our DB URI defines a replica set. `winston-mongodb` requires the name of the replica set to be included in the URI. Our original `DB_URI` doesn't include it. It is included though in the `LOGGING_DB_URI`.
