### PR TITLE
add html-entities module to unescape DonorsChoose retrieve proposal API ...

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -37,6 +37,7 @@ var mobilecommons = require('../../../../mobilecommons')
   , Q = require('q')
   , shortenLink = require('../../bitly')
   , logger = require('../../logger')
+  , Entities = require('html-entities').AllHtmlEntities
   ;
 
 function DonorsChooseDonationController(app) {
@@ -89,7 +90,8 @@ DonorsChooseDonationController.prototype.findProject = function(request, respons
     if (!error) {
       var donorsChooseResponse;
       try {
-        donorsChooseResponse = JSON.parse(data);
+        var entities = new Entities(); // Calling 'html-entities' module to decode escaped characters.
+        donorsChooseResponse = JSON.parse(entities.decode(data));
       }
       catch (e) {
         // JSON.parse will throw a SyntaxError exception if data is not valid JSON

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "connect-multiparty": "1.1.0",
     "express": "3.x",
+    "html-entities": "^1.1.1",
     "mobilecommons": ">=0.0.4",
     "mocha": "1.20.x",
     "mongoose": "~3.8.8",


### PR DESCRIPTION
#### What's this PR do?

The "retrieve proposals" API call to DonorsChoose returns JSON with escaped characters. This can look messy if the escaped characters show up on the texts we send to members. 

This PR adds a new module, "html-entities", in order to decode the escaped characters. 
#### How should this be manually tested?

First tested using the API call in [this file](https://gist.github.com/tongxiang/93f5e41413077c522421) to ensure that the escaping works, and then tested using Postman to run through the normal DonorsChoose donation flow. 
#### What are the relevant tickets?

JIRA SMS-95. 
