### PR TITLE
one of two users selecting success choice now delivers success end-level message to all users

### DIFF
--- a/app/controllers/SGCompetitiveStoryController.js
+++ b/app/controllers/SGCompetitiveStoryController.js
@@ -1008,14 +1008,7 @@ SGCompetitiveStoryController.prototype.getEndLevelGroupMessage = function(endLev
   var selectChoice = -1;
   var maxCount = -1;
   for (var i = 0; i < choiceCounter.length; i++) {
-    // Covers edge case --> if only 1 out of 2 users select the impact choice-set,
-    // the group will now receive the non-impact level ending message.
-    // (This is purely because the non-impact choice-set is always second in the array of choices.)
-
-    var isTwoPlayerGame = (gameDoc.players_current_status.length === 2);
-    var countEqualsMax = (choiceCounter[i] === maxCount);
-    var isNewMax = (choiceCounter[i] > maxCount);
-    if ((isTwoPlayerGame && countEqualsMax) || isNewMax){
+    if (choiceCounter[i] > maxCount) {
       selectChoice = i;
       maxCount = choiceCounter[i];
     }


### PR DESCRIPTION
#### What's this PR do?

Previously ([see commit here](https://github.com/DoSomething/ds-mdata-responder/pull/121)) we changed the end-level game logic so that if one out of two players select the success choice, they receive the non-success end-level choice. 

Now, we're reversing this end-level game logic so that if one out of two players select the success choice, they receive the success end-level choice. 
#### How should this be manually tested?

Tested with Postman with two players and a variety of combinations: 1/2 success, 2/2 success, 0/2 success. 
#### What are the relevant tickets?

JIRA SMS-92. 
