### PR TITLE
move response.send() function before zipcode validation, add log statements

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -226,7 +226,6 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
       }
     }
   )
-
   response.send();
 };
 
@@ -385,18 +384,22 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
     return;
   }
 
+  response.send();
+
   var config = dc_config[request.query.id];
   var location = messageHelper.getFirstWord(request.body.args);
 
   if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'zip') {
     if (!isValidZip(location)) {
       sendSMS(request.body.phone, config.invalid_zip_oip);
+      logger.info('User ' + request.body.phone + ' did not submit a valid zipcode in the DonorsChoose.org flow.');
       return;
     }
   }
   else if (TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR == 'state') {
     if (!isValidState(location)) {
       sendSMS(request.body.phone, config.invalid_state_oip);
+      logger.info('User ' + request.body.phone + ' did not submit a valid state abbreviation in the DonorsChoose.org flow.');
       return;
     }
   }
@@ -407,7 +410,6 @@ DonorsChooseDonationController.prototype.retrieveLocation = function(request, re
   };
 
   this._post('find-project?id=' + request.query.id, info);
-  response.send();
 };
 
 /**


### PR DESCRIPTION
#### What's this PR do?

During the DonorsChoose.org donation flow, if a user inputs an invalid zipcode, our `isValidZip()` validator returns us out of the function **before** our `retrieveLocation()` function returns a response. MobileCommons is left hanging, and we're sent a timeout error. 

To minimize these errors, given that we're handling the user's incorrect input by opting them into a new reminder message, I've moved the response.send() higher before the validation flow. 

We've also added some log statements to let us know if a user doesn't submit a valid zipcode or state abbreviation.
#### How should this be manually tested?

This has been tested by correctly running through the donations flow, and also by inputting an incorrectly formatted zipcode. In each case, we were able to successfully run through the donations flow. 
