### PR TITLE
change default request timeout from two minutes to four minutes

### DIFF
--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -7,10 +7,9 @@ var request = require('request')
   , logger = require('../app/lib/logger')
   ;
 
-// Modifying the default Request library's request object to have an 
-// extended timeout, rather than its default of 120000 ms. 
+// Modifying the default Request library's request object.
 var modifiedRequest = request.defaults({
-  timeout: 240000
+  timeout: 120000
 });
 
 /**


### PR DESCRIPTION
#### What's this PR do?

This extends the timeout of our `request.post()` calls to mobilecommons from 2 minutes to 4 minutes. We've created a modified request object within `mobilecommons.js` with its default timeout extended. 
#### How should this be manually tested?

By playing through a variety of game functions, the `mobilecommons.profile_update()` and `mobilecommons.optin()` functions were tested--they still work to opt in users and update their profiles. The actual timeout limit hasn't been tested. 
#### Any background context you want to provide?

Our requests to "https://secure.mcommons.com/profiles/join" subscribes users to opt in paths, unsubscribes them, and updates their profiles. Some of our calls to this API were throwing 408 timeout errors. 

It could be that MobileCommons' servers are taking a while to return a response. By extending the timeout of our Post request, we hope to mitigate these errors. 

Some more information, also written at #256:

[The request library](https://github.com/mikeal/request) specifies that its generic `request()` function takes the following argument: 

```
timeout - Integer containing the number of milliseconds to wait for a request to respond before aborting the request
```

We can also use the following method of setting default properties on requests to assign all POST requests the same timeout: 

```
//requests using baseRequest() will set the 'x-token' header
var baseRequest = request.defaults({
  headers: {x-token: 'my-token'}
})

//requests using specialRequest() will include the 'x-token' header set in
//baseRequest and will also include the 'special' header
var specialRequest = baseRequest.defaults({
  headers: {special: 'special value'}
})
```

But importantly--what is the default value of the timeout? 

Interesting question. It doesn't seem like the Request library itself specifies a default timeout value, but it looks like the Node.js native http library (which Request uses) [does specify a default timeout](http://nodejs.org/api/http.html#http_request_settimeout_timeout_callback) of 120000 ms (or 2 minutes.) 

```
server.timeout#
Number Default = 120000 (2 minutes)
The number of milliseconds of inactivity before a socket is presumed to have timed out.

Note that the socket timeout logic is set up on connection, so changing this value only affects new connections to the server, not any existing connections.

Set to 0 to disable any kind of automatic timeout behavior on incoming connections.
```
#### What are the relevant tickets?

Closes #256. 
