### PR TITLE
mobilecommons tests

### DIFF
--- a/app/eventEmitter.js
+++ b/app/eventEmitter.js
@@ -2,4 +2,11 @@ var events = require('events')
   ;
 
 var eventEmitter = new events.EventEmitter();
+
+events.EventEmitter.prototype.events = {
+  mcOptinTest: 'mobilecommons-optin-test',
+  mcOptoutTest: 'mobilecommons-optout-test',
+  mcProfileUpdateTest: 'mobilecommons-profile-update-test'
+};
+
 module.exports = eventEmitter;

--- a/mobilecommons/mobilecommons.js
+++ b/mobilecommons/mobilecommons.js
@@ -5,6 +5,7 @@
 
 var request = require('request')
   , logger = require('../app/lib/logger')
+  , emitter = require('../app/eventEmitter')
   ;
 
 // Modifying the default Request library's request object.
@@ -25,11 +26,6 @@ var modifiedRequest = request.defaults({
 */
 
 exports.profile_update = function(phone, optInPathId, customFields) {
-  if (process.env.NODE_ENV == 'test') {
-    logger.info('mobilecommons.profile_update: ', phone, ' | ', optInPathId, ' | ', customFields);
-    return;
-  }
-
   var url = 'https://secure.mcommons.com/api/profile_update';
   var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
   var authPass = process.env.MOBILECOMMONS_AUTH_PASS;
@@ -53,8 +49,14 @@ exports.profile_update = function(phone, optInPathId, customFields) {
     }
   }
 
-  var trace = new Error().stack;
+  // If we're in a test env, just log and emit an event.
+  if (process.env.NODE_ENV == 'test') {
+    logger.info('mobilecommons.profile_update: ', phone, ' | ', optInPathId, ' | ', customFields);
+    emitter.emit(emitter.events.mcProfileUpdateTest, postData);
+    return;
+  }
 
+  var trace = new Error().stack;
   modifiedRequest.post(url, postData, function(error, response, body) {
     if (error) {
       logger.error('Failed mobilecommons.profile_update for user phone: ' 
@@ -74,11 +76,6 @@ exports.profile_update = function(phone, optInPathId, customFields) {
  * Opt-in mobile numbers into specified Mobile Commons paths.
  */
 exports.optin = function(args) {
-  if (process.env.NODE_ENV == 'test') {
-    logger.info('mobilecommons.optin: ', args);
-    return;
-  }
-
   var url = 'https://secure.mcommons.com/profiles/join';
 
   var alphaPhone = args.alphaPhone || null;
@@ -109,12 +106,19 @@ exports.optin = function(args) {
       payload.form['friends[]'] = betaPhone;
     }
 
-    var trace = new Error().stack;
+    // If we're in a test env, just log and emit an event.
+    if (process.env.NODE_ENV == 'test') {
+      logger.info('mobilecommons.optin: ', args);
+      emitter.emit(emitter.events.mcOptinTest, payload);
+      return;
+    }
 
+    var trace = new Error().stack;
     modifiedRequest.post(url, payload, function(error, response, body) {
       if (error) {
         logger.error('Failed mobilecommons.optin for user: ' + alphaPhone 
           + ' | with request payload: ' + JSON.stringify(payload) 
+          + ' | with error: ' + JSON.stringify(error)
           + ' | stack: ' + trace);
       }
       else if (response) {
@@ -139,12 +143,19 @@ exports.optin = function(args) {
       }
     };
 
-    var trace = new Error().stack;
+    // If we're in a test env, just log and emit an event.
+    if (process.env.NODE_ENV == 'test') {
+      logger.info('mobilecommons.optin: ', args);
+      emitter.emit(emitter.events.mcOptinTest, payload);
+      return;
+    }
 
+    var trace = new Error().stack;
     modifiedRequest.post(url, payload, function(error, response, body) {
         if (error) {
           logger.error('Failed mobilecommons.optin for user: ' + alphaPhone 
             + ' | with request payload: ' + JSON.stringify(payload) 
+            + ' | with error: ' + JSON.stringify(error)
             + ' | stack: ' + trace);
         }
         else if (response) {
@@ -167,11 +178,6 @@ exports.optin = function(args) {
  * Opt out of a Mobile Commons campaign.
  */
 exports.optout = function(args) {
-  if (process.env.NODE_ENV == 'test') {
-    logger.info('mobilecommons.optout: ', args);
-    return;
-  }
-
   var url = 'https://secure.mcommons.com/profiles/opt_out';
 
   var phone = args.phone || null;
@@ -198,13 +204,20 @@ exports.optout = function(args) {
     }
   };
 
-  var trace = new Error().stack;
+  // If we're in a test env, just log and emit an event.
+  if (process.env.NODE_ENV == 'test') {
+    logger.info('mobilecommons.optout: ', args);
+    emitter.emit(emitter.events.mcOptoutTest, payload);
+    return;
+  }
 
+  var trace = new Error().stack;
   // Send opt-out request
   modifiedRequest.post(url, payload, function(error, response, body) {
       if (error) {
         logger.error('Failed mobilecommons.optout for user: ' + phone 
           + ' | with request payload: ' + JSON.stringify(payload.form) 
+          + ' | with error: ' + JSON.stringify(error)
           + ' | stack: ' + trace);
       }
       else if (response) {

--- a/test/mobilecommons.js
+++ b/test/mobilecommons.js
@@ -1,0 +1,228 @@
+/**
+ * Tests for the app-specific mobilecommons library.
+ */
+
+var assert = require('assert')
+  , mobilecommons = require('../mobilecommons')
+  , emitter = require('../app/eventEmitter')
+  ;
+
+var setMobileCommonsTestCredentials = function() {
+  process.env.MOBILECOMMONS_COMPANY_KEY = 'MOBILECOMMONS_COMPANY_KEY';
+  process.env.MOBILECOMMONS_AUTH_EMAIL = 'MOBILECOMMONS_AUTH_EMAIL';
+  process.env.MOBILECOMMONS_AUTH_PASS = 'MOBILECOMMONS_AUTH_PASS';
+};
+
+var unsetMobileCommonsTestCredentials = function() {
+  process.env.MOBILECOMMONS_COMPANY_KEY = undefined;
+  process.env.MOBILECOMMONS_AUTH_EMAIL = undefined;
+  process.env.MOBILECOMMONS_AUTH_PASS = undefined;
+};
+
+describe('mobilecommons.optin with just an Alpha', function() {
+  it('should emit optin event with correct payload', function(done) {
+    var test = {
+      alphaPhone: 5555550100,
+      alphaOptin: 123
+    };
+    var expected = {
+      form: {
+        opt_in_path: 123,
+        'person[phone]': 5555550100
+      }
+    };
+
+    emitter.on(emitter.events.mcOptinTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcOptinTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.optin(test);
+  })
+});
+
+describe('mobilecommons.optin with an Alpha and 1 Beta', function() {
+  it('should emit optin event with correct payload', function(done) {
+    var test = {
+      alphaPhone: 5555550100,
+      alphaOptin: 123,
+      betaPhone: 5555550101,
+      betaOptin: 456
+    };
+    var expected = {
+      form: {
+        opt_in_path: 123,
+        friends_opt_in_path: 456,
+        'person[phone]': 5555550100,
+        'friends[]': 5555550101
+      }
+    };
+
+    emitter.on(emitter.events.mcOptinTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcOptinTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.optin(test);
+  })
+});
+
+describe('mobilecommons.optin with Alpha and 2 Betas', function() {
+  it('should emit optin event with correct payload', function(done) {
+    var test = {
+      alphaPhone: 5555550100,
+      alphaOptin: 123,
+      betaPhone: [5555550101, 5555550102],
+      betaOptin: 456
+    };
+    var expected = {
+      form: {
+        opt_in_path: 123,
+        friends_opt_in_path: 456,
+        'person[phone]': 5555550100,
+        'friends[0]': 5555550101,
+        'friends[1]': 5555550102,
+      }
+    };
+
+    emitter.on(emitter.events.mcOptinTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcOptinTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.optin(test);
+  })
+});
+
+describe('mobilecommons.optout', function() {
+  before(setMobileCommonsTestCredentials);
+
+  it('should emit optout event with correct payload', function(done) {
+    var test = {
+      phone: 5555550100,
+      campaignId: 123
+    };
+    var expected = {
+      auth: {
+        user: 'MOBILECOMMONS_AUTH_EMAIL',
+        pass: 'MOBILECOMMONS_AUTH_PASS'
+      },
+      form: {
+        'person[phone]': 5555550100,
+        campaign: 123,
+        company_key: 'MOBILECOMMONS_COMPANY_KEY'
+      }
+    };
+
+    emitter.on(emitter.events.mcOptoutTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcOptoutTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.optout(test);
+  });
+
+  after(unsetMobileCommonsTestCredentials);
+});
+
+describe('mobilecommons.profile_update', function() {
+  before(setMobileCommonsTestCredentials); 
+
+  it('should emit profile_update event with correct payload', function(done) {
+    var test = {
+      phone: 5555550100,
+      optInPathId: 123
+    };
+    var expected = {
+      auth: {
+        user: 'MOBILECOMMONS_AUTH_EMAIL',
+        pass: 'MOBILECOMMONS_AUTH_PASS'
+      },
+      form: {
+        phone_number: 5555550100,
+        opt_in_path_id: 123
+      }
+    };
+
+    emitter.on(emitter.events.mcProfileUpdateTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.profile_update(test.phone, test.optInPathId);
+  });
+
+  after(unsetMobileCommonsTestCredentials);
+});
+
+describe('mobilecommons.profile_update with custom fields', function() {
+  before(setMobileCommonsTestCredentials);
+
+  it('should emit profile_update event with correct payload', function(done) {
+    var test = {
+      phone: 5555550100,
+      optInPathId: 123,
+      customFields: {
+        field1: 1,
+        field2: 'abc'
+      }
+    };
+    var expected = {
+      auth: {
+        user: 'MOBILECOMMONS_AUTH_EMAIL',
+        pass: 'MOBILECOMMONS_AUTH_PASS'
+      },
+      form: {
+        phone_number: 5555550100,
+        opt_in_path_id: 123,
+        field1: 1,
+        field2: 'abc'
+      }
+    };
+
+    emitter.on(emitter.events.mcProfileUpdateTest, function(payload) {
+      emitter.removeAllListeners(emitter.events.mcProfileUpdateTest);
+
+      if (JSON.stringify(payload) == JSON.stringify(expected)) {
+        done();
+      }
+      else {
+        assert(false, "Actual payload doesn't match what's expected.");
+      }
+    });
+
+    mobilecommons.profile_update(test.phone, test.optInPathId, test.customFields);
+  });
+
+  after(unsetMobileCommonsTestCredentials);
+});


### PR DESCRIPTION
#### What's this PR do?

Adds tests for our app-specific mobilecommons library. Added an `events` property to `eventEmitter` so that there's a single place where custom emitted events get named. And put in some additional logging when mobilecommons responds with an error.
#### Where should the reviewer start?
- `app/eventEmitter.js`
  An `events` property is added where our custom events can live. This can help protect us from copy & paste bugs and if event names ever need to change, a single place to do it.
- `mobilecommons/mobilecommons.js`
  When `NODE_ENV=test`, in addition to logging, we'll be emitting corresponding events. I've also moved that `if` block further into each function just before the actual http requests. This'll allow our tests to check against the data that's suppose to be sent.
- `test/mobilecommons.js`
  This does basic coverage of optin with just an Alpha, optin with one Beta, optin with two Betas, optout of a single campaign, profile_update with no custom fields, and profile_update with two custom fields.
#### How should this be manually tested?

Run `npm test` and verify it all succeeds. Or just wait for wercker to build, because there's test step in the build process.
#### What are the relevant tickets?
#31
