### PR TITLE
Modularize player creation DB call

### DIFF
--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -53,8 +53,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
   }
 
   // Allows us to use the .findUserGame(obj, onUserGameFound) 
-  // helper function function.
-  
+  // helper function.
   this.request = request;
   this.response = response;
   if (!this.request.body) {
@@ -154,36 +153,15 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     message.endGameFromPlayerExit(playerDocs);
 
     // Upsert the document for the alpha user.
-    // userModel.update(
-    //   {phone: self.createdGameDoc.alpha_phone},
-    //   {$set: {phone: self.createdGameDoc.alpha_phone, current_game_id: self.createdGameDoc._id, updated_at: Date.now()}},
-    //   {upsert: true}, // Creates a new doc when no doc matches the query criteria via '.update()'.
-    //   function(err, num, raw) {
-    //     if (err) {
-    //       logger.error(err);
-    //     }
-    //     else {
-    //       // This response.sendStatus() call has been moved from outside into this 
-    //       // async Mongoose call to ensure that upon SOLO game creation, 
-    //       // the Alpha userModel will have been modified with the SOLO gameId before 
-    //       // the start game logic runs (triggered by the POST to the /alpha-start route.)
-    //       response.sendStatus(201);
-    //       emitter.emit('alpha-user-created');
+    // This response.sendStatus() call fires after the async Mongoose call returns
+    // so that upon SOLO game creation, the Alpha userModel will have been modified 
+    // with the SOLO gameId before the start game logic runs 
+    // (triggered by the POST to the /alpha-start route.)
+    createPlayer(self.createdGameDoc.alpha_phone, self.createdGameDoc._id, 'alpha-user-created', function(){ self.response.sendStatus(201); });
 
-    //       if (raw && raw.upserted) {
-    //         logger.info('Alpha user upserted: ', JSON.stringify(raw.upserted));
-    //       }
-    //     }
-    //   });
-
-    createPlayer(self.createdGameDoc.alpha_phone, self.createdGameDoc._id, 'alpha-user-created', 'Alpha user upserted: ').exec()
-
-    .then(function() { self.response.sendStatus(201) }, 
-      utility.promiseErrorCallback(err));
-
+    // Upsert user documents for the betas.
     self.createdGameDoc.betas.forEach(function(value, index, set) {
-      // Upsert user document for the beta.
-      createPlayer(value.phone, self.createdGameDoc._id, 'beta-user-created', 'Beta user upserted: ').exec();
+      createPlayer(value.phone, self.createdGameDoc._id, 'beta-user-created');
     });
 
     var betaOptInArray = []; // Extract phone number for Mobile Commons opt in.
@@ -210,29 +188,23 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
   utility.stathatReportCount(STATHAT_CATEGORY, stathatAction, 'success', this.storyId, 1);
   return true;
 
-  function createPlayer(phone, docId, emitterMessage, loggerMessage) {
-    return userModel.update(
+  function createPlayer(phone, docId, emitterMessage, onSuccess) {
+    userModel.update(
       {phone: phone},
       {$set: {phone: phone, current_game_id: docId, updated_at: Date.now()}},     
-      {upsert: true},
-      function(err, num, raw) {
-        if (err) {
-          logger.error(err);
-        }
-        else {
-          emitter.emit(emitterMessage);
-
-          if (raw && raw.upserted) {
-            logger.info(loggerMessage, JSON.stringify(raw.upserted));
-          }
-        }
+      {upsert: true}
+    ).exec().then(function(num, raw) {
+      emitter.emit(emitterMessage);
+      if (raw && raw.upserted) {
+        logger.info(emitterMessage, JSON.stringify(raw.upserted));
       }
-    );
+      if (typeof onSuccess === 'function') {
+        onSuccess();
+      }
+    }, utility.promiseErrorCallback('Unable to create player, this event did not happen: ' + emitterMessage)
+    )
   }
-
 };
-
-
 
 /**
  * @todo consider moving all of the join game behavior to a parent class SGGameController


### PR DESCRIPTION
#### What's this PR do?

It was pretty difficult to find material within the `.createGame()` function that was worth refactoring. And I'm honestly not sure if this PR is necessary, for reasons I'll talk about below. 

We previously had two sets of Mongoose code for the alpha-user and beta-user creation process. I pulled this out into a single function `createPlayer`, called in both cases. There are two things worth noticing here:
1. The function `createPlayer` takes a final argument, `extraCallback`, which allows the alpha creation function to send a response. This is necessary for alpha-solo game creation to work, as noted in the comments above this function call. 
2. The `logger.info` calls now log the same messages that the emitter emits. (I originally had the logger message strings inputted as an argument to `createPlayer`, but I thought this was unnecessary. Feel free to disagree--there's definitely utility in having consistent logging messages, and I don't want to change the messages halfway through our log files.) 

**Why do I feel like this is unnecessary?**
The `createPlayer` function saves maybe ~25 lines of code, but I think it might also make the code more confusing. Would it be simpler to just have the mongoose calls exposed, with the contents of their callbacks obvious?
#### How should this be manually tested?

I tested this with `npm test`, as well as using postman to make sure alpha-solo game creation and play still works. 
#### What are the relevant tickets?

Closes #320. 
#### Questions:

@jonuy--thoughts? Think this is necessary? (Definitely think finding ways to refactor `.createGame()` took way too much time. Trying to learn when it's not worth it!)
