### PR TITLE
add automatic beta-solo play to `endGameFromPlayerExit()`

### DIFF
--- a/app/lib/sms-games/controllers/SGSoloController.js
+++ b/app/lib/sms-games/controllers/SGSoloController.js
@@ -75,7 +75,7 @@ SGSoloController.prototype.processRequest = function(request, response) {
   }
 
   this.createSoloGame(request.get('host'), request.query.story_id, request.query.story_type, request.body.phone);
-
+  
   response.send();
 }
 


### PR DESCRIPTION
#### What's this PR do?

If a player's game is ended from another player exiting, this PR automatically creates a solo game from them, and opts them into this game. 

The PR will become a lot clearer when the previous PR, #349 gets merged into dev. 

Note that: 
This PR also attaches a new globally-accessible flag to `app`: `app.hostName`, which provides a hard-coded store of the app's hostname. We did this because the `.endGameFromPlayerExit` function only takes in playerDocs, and doesn't have a clear way to reference the app's host URL for the `SGSoloController.createSoloGame()` function call.

It is troubling to both me and @jonuy that all our solo game creation logic is asynchronously hitting our app's API routes, instead of simply calling those functions synchronously. We should refactor this in the future, and refactor the entire SGSoloController functionality. 
#### How should this be manually tested?

Used `npm test` to show that `endGameFromPlayerExit()` functionality still works, and used Postman to show that a player whose game has ended gets placed into a new solo game. 
#### What are the relevant tickets?

Contributes to the closing of #243.
