### PR TITLE
Increasing max sockets to 20

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,10 +6,14 @@ if (process.env.NODE_ENV == 'production') {
 var express = require('express')
     , path = require('path')
     , logger = require('./app/lib/logger')
+    , http = require('http')
     ;
 
 // Set application root to global namespace
 global.appRoot = path.resolve(__dirname);
+
+// Default is 5. Increasing # of concurrent sockets per host.
+http.globalAgent.maxSockets = 20;
 
 /**
  * Express Setup - note app as global variable


### PR DESCRIPTION
#### What's this PR do?

Increases the number of concurrent sockets per host to 20. Pretty much all requests this app fields will be from Mobile Commons, so I think it'd make sense that we could hit our limit with particularly high volume.

Express uses the `http` module, so setting the global agent setting here works.
#### How should this be manually tested?

I tested with `$ npm test` and POSTing to `ds-routing/tips`.
#### What are the relevant tickets?

Closes #339
