### PR TITLE
A/B testing autostart functionality

### DIFF
--- a/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
+++ b/app/lib/sms-games/controllers/SGCompetitiveStoryController.js
@@ -123,7 +123,7 @@ SGCompetitiveStoryController.prototype.createGame = function(request, response) 
     var config = gameConfig[doc.story_id];
 
     // doc.story_id check added in order to A/B test auto-start functionality. 
-    if (doc.game_type != "solo" && doc.story_id == 102) {
+    if (doc.game_type != "solo" && doc.story_id == 201) {
     // Automatically starts game after specified delay, or opts alpha into solo play.
       start.auto(doc._id);
     }

--- a/app/lib/sms-games/controllers/logicGameStart.js
+++ b/app/lib/sms-games/controllers/logicGameStart.js
@@ -7,8 +7,7 @@ var gameConfig = require('../config/competitive-stories')
   , SGSoloController = require('./SGSoloController')
   , emitter = require('../../../eventEmitter')
   , STATHAT_CATEGORY = 'sms-games'
-  // , AUTO_START_GAME_DELAY = 300000;
-  , AUTO_START_GAME_DELAY = 5000;
+  , AUTO_START_GAME_DELAY = 300000;
 
 module.exports = {
   game : startGame,


### PR DESCRIPTION
#### What's this PR do?

The ID of the alternate testing version of Science Sleuth is 201. This PR adds a flag to our auto-start functionality for Optimizely testing--if the ID of the game created (transmitted via the POST query params) is 201, then we'll run our autostart game function. Otherwise, the alpha will be sent the typical message at five minutes asking if she wants to play solo. 

This PR also changes the auto-start delay time to five minutes. 
#### How should this be manually tested?

`npm test`! Also, created both `201` id'd and `101` id'd games via Postman, and checked to make sure that the requisite behavior happened. 
