### PR TITLE
Removing extraneous closure references in SMS games

### DIFF
--- a/app/lib/sms-games/controllers/logicAlphaStart.js
+++ b/app/lib/sms-games/controllers/logicAlphaStart.js
@@ -8,10 +8,9 @@ var emitter = rootRequire('app/eventEmitter')
  * Callback after alpha's game is found. Handles an alpha choosing to start
  * the game before all players have joined.
  */
-module.exports = function(obj, doc) {
+module.exports = function(request, doc) {
   // Start the game.
   doc = start.game(doc);
-  obj.response.send();
 
   // Save the doc in the database with the current status updates.
   gameModel.update(

--- a/app/lib/sms-games/controllers/logicBetaJoin.js
+++ b/app/lib/sms-games/controllers/logicBetaJoin.js
@@ -14,8 +14,8 @@ var emitter = rootRequire('app/eventEmitter')
  * game-pending messages if all players haven't joined yet, or auto-start the
  * game if all players are joined.
  */
-module.exports = function(obj, doc) {
-  var joiningBetaPhone = obj.request.body.phone;
+module.exports = function(request, doc) {
+  var joiningBetaPhone = request.body.phone;
 
   // If the game's already started, notify the user and exit.
   if (doc.game_started || doc.game_ended) {
@@ -25,9 +25,8 @@ module.exports = function(obj, doc) {
     var soloController = new SGSoloController;
     setTimeout(
       function() {
-        soloController.createSoloGame(obj.request.get('host'), doc.story_id, 'competitive-story', joiningBetaPhone)
+        soloController.createSoloGame(request.get('host'), doc.story_id, 'competitive-story', joiningBetaPhone)
       } , BETA_TO_SOLO_AFTER_GAME_ALREADY_STARTED_DELAY);
-    obj.response.send();
     return;
   }
 
@@ -52,13 +51,11 @@ module.exports = function(obj, doc) {
   // If all have joined, then start the game.
   if (allJoined) {
     doc = start.game(doc);
-    obj.response.send();
   }
   // If we're still waiting on people, send appropriate messages to the recently
   // joined beta and alpha users.
   else {
     doc = message.wait(gameConfig, doc, joiningBetaPhone);
-    obj.response.send();
   }
 
   // Save the doc in the database with the betas and current status updates.

--- a/app/lib/sms-games/controllers/logicUserAction.js
+++ b/app/lib/sms-games/controllers/logicUserAction.js
@@ -20,13 +20,13 @@ var END_LEVEL_GROUP_MESSAGE_DELAY = 15000
  * Callback after user's game is found. Determines how to progress the user
  * forward in the story based on her answer.
  */
-module.exports = function(obj, doc) {
+module.exports = function(request, doc) {
   var gameDoc = doc;
   // Uppercase and only get first word of user's response.
-  var userFirstWord = smsHelper.getFirstWord(obj.request.body.args.toUpperCase());
+  var userFirstWord = smsHelper.getFirstWord(request.body.args.toUpperCase());
 
   // Find player's current status.
-  var userPhone = smsHelper.getNormalizedPhone(obj.request.body.phone);
+  var userPhone = smsHelper.getNormalizedPhone(request.body.phone);
   var currentOip = 0;
   for (var i = 0; i < doc.players_current_status.length; i++) {
     if (doc.players_current_status[i].phone == userPhone) {
@@ -132,11 +132,9 @@ module.exports = function(obj, doc) {
   // in the logicUserAction() function call.
   if (userPhone && nextOip) {
     message.singleUser(userPhone, nextOip);
-
-    obj.response.send();
   }
   else {
-    obj.response.status(500).send('Story configuration invalid.');
+    logger.error('Story configuration invalid. phone: ' + userPhone + ' story_id: ' + doc.story_id);
   }
 };
 


### PR DESCRIPTION
#### What's this PR do?

Cleans up the data we're closing over for callbacks in SGCompetitiveStory game flows - creation, joining, starting, playing. In many places we would do...

```
var self = this;
self.response = response;
self.request = request;
```

We did this to have references to models and configs that were previously attached to the `this` object. And we kept it around because we'd also reference the `response` object to send responses back to the client from within callbacks.

This PR removes the closures around the `this` and `response` objects. It also moves the responses to the client out of the callbacks. Responses are sent immediately as opposed to waiting for async processes to complete. (This should further improve throughput.) Any errors in the async processes are logged instead.
#### How should this be manually tested?

I tested by running `npm test` and going through the first half of a test SMS game through Postman.
#### What are the relevant tickets?

Closes #332 
Closes #331 
