### PR TITLE
add connection object to sgGameCreateConfig model

### DIFF
--- a/app/lib/sms-games/controllers/SGCreateFromMobileController.js
+++ b/app/lib/sms-games/controllers/SGCreateFromMobileController.js
@@ -10,7 +10,8 @@ var requestHttp = require('request')
   , smsHelper = rootRequire('app/lib/smsHelpers')
   , logger = rootRequire('app/lib/logger')
   , competitiveStoryConfig = require('../config/competitive-stories')
-  , configModel = require('../models/sgGameCreateConfig')
+  , connectionOperations = rootRequire('app/config/connectionOperations')
+  , configModel = require('../models/sgGameCreateConfig')(connectionOperations)
   ;
 
 var gameConfig;

--- a/app/lib/sms-games/models/sgGameCreateConfig.js
+++ b/app/lib/sms-games/models/sgGameCreateConfig.js
@@ -30,4 +30,6 @@ var sgGameCreateConfigSchema = new mongoose.Schema({
   story_type: String
 })
 
-module.exports = mongoose.model('sg_gamecreateconfig', sgGameCreateConfigSchema);
+module.exports = function(connection) {
+  return connection.model('sg_gamecreateconfig', sgGameCreateConfigSchema);
+}


### PR DESCRIPTION
#### What's this PR do?

Adds the connection object to the sgGameCreateConfig.js model, adds it to its require() statement within the SGCreateFromMobileCotroller. 
### How should this be manually tested?

`npm test`! 

JK JK JK JK we don't have that kind of test coverage. 

Use [this postman collection](https://www.getpostman.com/collections/c80e640b4d48ca44b66c) to create and test. 
