### PR TITLE
Limits users to max 5 donations

### DIFF
--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -27,7 +27,7 @@ var donorsChooseApiKey = (process.env.DONORSCHOOSE_API_KEY || null)
 if (process.env.NODE_ENV == 'test') {
   donorsChooseApiKey = 'DONORSCHOOSE';
   donorsChooseApiPassword = 'helpClassrooms!';
-  donorsChooseDonationBaseURL = 'https://apiqasecure.donorschoose.org/common/json_api.html?APIKey=';
+  donorsChooseDonationBaseURL = 'https://dev1-apisecure.donorschoose.org/common/json_api.html?APIKey=';
 }
 
 var TYPE_OF_LOCATION_WE_ARE_QUERYING_FOR = 'zip' // 'zip' or 'state'. Our retrieveLocation() function will adjust accordingly.

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -108,11 +108,11 @@ DonorsChooseDonationController.prototype.start = function(request, response) {
 
     // If user has not hit the max limit, start the donation flow.
     if (!config.max_donations_allowed || donationsCount < config.max_donations_allowed) {
-      sendSMS(phone, config.max_donations_reached_oip);
+      sendSMS(phone, config.start_donation_flow);
     }
     // Otherwise, send an error message
     else {
-      sendSMS(phone, config.start_donation_flow);
+      sendSMS(phone, config.max_donations_reached_oip);
     }
   }
 };

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -315,7 +315,18 @@ DonorsChooseDonationController.prototype.retrieveEmail = function(request, respo
  *
  */
 DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject, donorInfoObject, proposalId, donationConfig) {
-  // First request: obtains a unique token for the donation.
+  var donorPhone;
+
+  donorPhone = smsHelper.getNormalizedPhone(donorInfoObject.donorPhoneNumber);
+
+  requestToken().then(requestDonation,
+    promiseErrorCallback('Unable to successfully retrieve donation token from DonorsChoose.org API. User mobile: '
+      + donorPhone)
+  );
+
+  /**
+   * First request: obtains a unique token for the donation.
+   */
   function requestToken() {
     // Creates promise-storing object.
     var deferred = Q.defer();
@@ -333,27 +344,29 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
             deferred.resolve(JSON.parse(body).token);
           } else {
             logger.error('Unable to retrieve a donation token from the DonorsChoose API for user mobile:' 
-              + donorInfoObject.donorPhoneNumber);
-            sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+              + donorPhone);
+            sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
           }
         }
         catch (e) {
           logger.error('Failed trying to parse the donation token request response from DonorsChoose.org for user mobile:' 
-            + donorInfoObject.donorPhoneNumber + ' Error: ' + e.message + '| Response: ' + response + '| Body: ' + body);
-          sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+            + donorPhone + ' Error: ' + e.message + '| Response: ' + response + '| Body: ' + body);
+          sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
         }
       }
       else {
         deferred.reject('Was unable to retrieve a response from the submit donation endpoint of DonorsChoose.org, user mobile: ' 
-          + donorInfoObject.donorPhoneNumber + 'error: ' + err);
-        sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+          + donorPhone + 'error: ' + err);
+        sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
       }
     });
     return deferred.promise;
   }
 
-  // After promise we make the second request: donation transaction.
-  requestToken().then(function(tokenData) {
+  /**
+   * After promise we make the second request: donation transaction.
+   */
+  function requestDonation(tokenData) {
     var donateParams = {'form': {
       'APIKey': apiInfoObject.apiKey,
       'apipassword': apiInfoObject.apiPassword, 
@@ -372,41 +385,107 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
       logger.log('debug', 'Donation submission return:', body.trim())
       if (err) {
         logger.error('Was unable to retrieve a response from the submit donation endpoint of DonorsChoose.org, user mobile: ' + donorInfoObject.donorPhoneNumber + 'error: ' + err);
-        sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+        sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
       }
       else if (response && response.statusCode != 200) {
         logger.error('Failed to submit donation to DonorsChoose.org for user mobile: ' 
-          + donorInfoObject.donorPhoneNumber + '. Status code: ' + response.statusCode + ' | Response: ' + response);
-        sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+          + donorPhone + '. Status code: ' + response.statusCode + ' | Response: ' + response);
+        sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
       }
       else {
         try {
           var jsonBody = JSON.parse(body);
           if (jsonBody.statusDescription == 'success') {
             logger.info('Donation to proposal ' + proposalId + ' was successful! Body:', jsonBody);
-            // Uses Bitly to shorten the link, then updates the user's MC profile.
-            shortenLink(jsonBody.proposalURL, function(shortenedLink) {
-              var customFields = {
-                donorsChooseProposalUrl: shortenedLink
-              };
-              mobilecommons.profile_update(donorInfoObject.donorPhoneNumber, donationConfig.donate_complete, customFields);
-            })
-          } else {
+            updateUserWithDonation();
+            sendSuccessMessage(jsonBody.proposalURL);
+          }
+          else {
             logger.warn('Donation to proposal ' + proposalId + ' for user mobile: ' 
-              + donorInfoObject.donorPhoneNumber + ' was NOT successful. Body:' + JSON.stringify(jsonBody));
-            sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+              + donorPhone + ' was NOT successful. Body:' + JSON.stringify(jsonBody));
+            sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
           }
         }
         catch (e) {
           logger.error('Failed trying to parse the donation response from DonorsChoose.org. User mobile: ' 
-            + donorInfoObject.donorPhoneNumber + 'Error: ' + e.message);
-          sendSMS(donorInfoObject.donorPhoneNumber, donationConfig.error_direct_user_to_restart);
+            + donorPhone + 'Error: ' + e.message);
+          sendSMS(donorPhone, donationConfig.error_direct_user_to_restart);
         }
       }
     })
-  },
-  promiseErrorCallback('Unable to successfully retrieve donation token from DonorsChoose.org API. User mobile: ' 
-    + donorInfoObject.donorPhoneNumber)); 
+  }
+
+  /**
+   * Start donation process.
+   */
+  function updateUserWithDonation() {
+    userModel.findOne({phone: donorPhone}, function(err, doc) {
+      if (err) {
+        logger.error(err);
+      }
+
+      if (!doc) {
+        userModel.create({phone: donorPhone})
+          .then(incrementDonationCount);
+      }
+      else {
+        incrementDonationCount(doc);
+      }
+    });
+  }
+
+  /**
+   * Updates the donation count in a user's donation history.
+   *
+   * @param doc
+   *   Document for user that made a donation
+   */
+  function incrementDonationCount(doc) {
+    var countUpdated = false;
+
+    if (!doc) {
+      return;
+    }
+
+    // Find previous donation history and increment the count if found
+    for (i = 0; i < doc.donations.length; i++) {
+      if (doc.donations[i].config_id == donationConfig._id) {
+        doc.donations[i].count += 1;
+        countUpdated = true;
+        break;
+      }
+    }
+
+    // If no previous donation found, add a new item
+    if (!countUpdated) {
+      doc.donations[doc.donations.length] = {
+        config_id: donationConfig._id,
+        count: 1
+      }
+    }
+
+    // Update the user document
+    userModel.update(
+      {phone: doc.phone},
+      {$set: {donations: doc.donations}}
+    );
+  }
+
+  /**
+   * Sends message to user after a successful donation.
+   *
+   * @param url
+   *   URL to the DonorsChoose project
+   */
+  function sendSuccessMessage(url) {
+    // Uses Bitly to shorten the link, then updates the user's MC profile.
+    shortenLink(url, function(shortenedLink) {
+      var customFields = {
+        donorsChooseProposalUrl: shortenedLink
+      };
+      mobilecommons.profile_update(donorPhone, donationConfig.donate_complete, customFields);
+    });
+  }
 };
 
 /**

--- a/app/lib/donations/controllers/DonorsChooseDonationController.js
+++ b/app/lib/donations/controllers/DonorsChooseDonationController.js
@@ -107,7 +107,7 @@ DonorsChooseDonationController.prototype.start = function(request, response) {
     config = app.getConfig(app.ConfigName.DONORSCHOOSE, configId);
 
     // If user has not hit the max limit, start the donation flow.
-    if (donationsCount < config.max_donations_allowed) {
+    if (!config.max_donations_allowed || donationsCount < config.max_donations_allowed) {
       sendSMS(phone, config.max_donations_reached_oip);
     }
     // Otherwise, send an error message
@@ -441,6 +441,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
    *   Document for user that made a donation
    */
   function incrementDonationCount(doc) {
+    var i;
     var countUpdated = false;
 
     if (!doc) {
@@ -468,7 +469,7 @@ DonorsChooseDonationController.prototype.submitDonation = function(apiInfoObject
     userModel.update(
       {phone: doc.phone},
       {$set: {donations: doc.donations}}
-    );
+    ).exec();
   }
 
   /**

--- a/app/lib/donations/donations.js
+++ b/app/lib/donations/donations.js
@@ -60,6 +60,21 @@ function implementsInterface(controller) {
   }
 }
 
+/**
+ * Starts the donation flow. Any validation needed before a donation flow
+ * begins should happen here. This endpoint will typically need to be
+ * triggered via an mData.
+ */
+router.post('/:controller/start', function(request, response) {
+  var controller = loadController(request.params.controller);
+  if (controller) {
+    controller.start(request, response);
+  }
+  else {
+    response.status(404).send('Request not available for: ' + request.params.controller);
+  }
+});
+
 router.post('/:controller/find-project', function(request, response) {
   var controller = loadController(request.params.controller);
   if (controller) {

--- a/app/lib/donations/models/donorschooseConfigModel.js
+++ b/app/lib/donations/models/donorschooseConfigModel.js
@@ -31,7 +31,13 @@ var donorschooseConfigSchema = new mongoose.Schema({
   donate_complete: Number,
 
   // Error notification OIP. 
-  error_direct_user_to_restart: Number
+  error_direct_user_to_restart: Number,
+
+  // Maximum number of donations a user can make for this campaign.
+  max_donations_allowed: Number,
+
+  // OIP sent when the maximum number of donations has already been sent.
+  max_donations_reached_oip: Number
 
 })
 

--- a/app/lib/sms-games/models/sgUser.js
+++ b/app/lib/sms-games/models/sgUser.js
@@ -15,7 +15,15 @@ var sgUserSchema = new mongoose.Schema({
   name: String,
 
   // _id of the game the user is currently in
-  current_game_id: mongoose.Schema.Types.ObjectId
+  current_game_id: mongoose.Schema.Types.ObjectId,
+
+  // Donation history
+  donations: [
+    {
+      config_id: Number,
+      count: Number
+    }
+  ]
 })
 
 module.exports = function(connection) {


### PR DESCRIPTION
#### What's this PR do?

Users will be able to make donations for a single campaign up to 5 times (or whatever is set in the config doc). The configuration for a donation flow now includes a `max_donations_allowed` and `max_donations_reached_oip` property. The first sets the number of donations a single user is allowed to make. The second provides the Mobile Commons opt-in path that a user should be sent to if they attempt to donate past the maximum amount.
#### Where should the reviewer start?
- **DonorsChooseDonationController.prototype.start:** Checks if the user has reached the max donation limit.
- **DonorsChooseDonationController.prototype.submitDonation:** Refactored a bit to move the code that's immediately run in this function to the top. All the closure functions are then listed underneath.
- **updateUserWithDonation** and **incrementDonationCount** are the functions that handle updating a user's donation history.
- **sgUser.js:** user model stores the donation count
- **donorschooseConfigModel.js** config properties added for handling max donations
#### How did I test?

Tested through Postman simulating the requests Mobile Commons would make to our app through mDatas.
1. /donations/donors-choose/start?id=[test id]
2. /donations/donors-choose/retrieve-location?id=[test id]
3. /donations/donors-choose/retrieve-firstname?id=[test id]
4. /donations/donors-choose/retrieve-email?id=[test id]
#### What are the relevant tickets?
#476
