### PR TITLE
Skipping end level success/failure messages

### DIFF
--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -126,12 +126,6 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     return;
   }
 
-  // If no end_level_* messages are specified, then return.
-  if (!gameConfig.end_level_0_correct_loss && !gameConfig.end_level_1_correct_loss &&
-      !gameConfig.end_level_solo_correct_win && !gameConfig.end_level_1_to_4_correct_win) {
-    return;
-  }
-
   var i, j
     , path
     , alphaPlayer
@@ -209,7 +203,14 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
   args = {'players_who_succeeded_at_end_level' : nameString};
 
   for (i = 0; i < allPlayers.length; i++) {
-    message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, args);
+    // If no individual end-level win/loss message is set in the configs, only update the profile.
+    if (!endLevelMessage) {
+      mobilecommons.profile_update(allPlayers[i].phone, '', args);
+    }
+    else {
+      message.singleUserWithDelay(allPlayers[i].phone, endLevelMessage, delay, gameDoc._id, userModel, args);
+    }
+
     emitter.emit('end-level-player-name-message', {'players_who_succeeded_at_end_level' : nameString, 'endLevelMessage': endLevelMessage});
   }
 }

--- a/app/lib/sms-games/controllers/playerNameHelpers.js
+++ b/app/lib/sms-games/controllers/playerNameHelpers.js
@@ -126,6 +126,12 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
     return;
   }
 
+  // If no end_level_* messages are specified, then return.
+  if (!gameConfig.end_level_0_correct_loss && !gameConfig.end_level_1_correct_loss &&
+      !gameConfig.end_level_solo_correct_win && !gameConfig.end_level_1_to_4_correct_win) {
+    return;
+  }
+
   var i, j
     , path
     , alphaPlayer
@@ -154,7 +160,12 @@ function endLevelMessageWithSuccessPlayerNames(gameConfig, gameDoc, delay) {
 
   // assembling an array with all player data
   alphaPlayer = { "name": gameDoc.alpha_name, "phone": gameDoc.alpha_phone };
-  allPlayers = gameDoc.betas;
+  allPlayers = [];
+  for (i = 0; i < gameDoc.betas.length; i++) {
+    if (gameDoc.betas[i].invite_accepted) {
+      allPlayers.push(gameDoc.betas[i]);
+    }
+  }
   allPlayers.push(alphaPlayer);
 
   // assembling a string of all the correct players' names


### PR DESCRIPTION
#### What's this PR do?

At the end of a level, if no success/failure messages are defined in a game's config, then skip it.

Also includes a bug fix where it seemed like end level messages would get sent to betas who didn't accept the invite to a game
#### How was this tested?

This was tested with two players in a ScienceSleuth2015 game. I tried both with the `end_level_*` properties configured and without it. With them defined, it sent the end level success/failure messages. Without them, it didn't and sent just the group message instead.
#### Any background context?

https://trello.com/c/YGeIyhC9/249-deactivate-the-messaging-associated-with-these-oips-for-end-level-feedback-see-description-for-links

ScienceSleuth2015 content has been setup so that the failure/success names are built into the group end level message
#### TODOs

We'll need to update the production db to unset `end_level_0_correct_loss`, `end_level_solo_correct_win`, `end_level_1_to_4_correct_win`, and `end_level_1_correct_loss` on the ScienceSleuth2015 config.
