### PR TITLE
Adds a save_to and config_override query params to the reportback flow

### DIFF
--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -23,6 +23,24 @@ else {
   REPORTBACK_PERMALINK_BASE_URL = 'http://staging.beta.dosomething.org/reportback/';
 }
 
+/**
+ * Single endpoint through which a reportback is created, populated and
+ * submitted. The expected reportback flow is that a user is asked for a photo,
+ * a caption, the reportback quantity and finally why it's important to them.
+ *
+ * POST /reportback/:campaign
+ *
+ * Query Params:
+ *   save_to - (optional) force this response to save to the specified field
+ *     Valid options: photo, caption, quantity, why_important
+ *
+ * Body Params:
+ *   args - the user's text response
+ *   mms_image_url - if set, the URL of the photo the user submitted
+ *   phone - the user's phone number
+ *   profile_first_completed_campaign_id - if set, the id of the first Mobile
+ *     Commons campaign the user has completed
+ */
 router.post('/:campaign', function(request, response) {
   var campaign
     , campaignConfig
@@ -51,7 +69,8 @@ router.post('/:campaign', function(request, response) {
             phone: phone,
             args: request.body.args,
             mms_image_url: request.body.mms_image_url,
-            profile_first_completed_campaign_id: request.body.profile_first_completed_campaign_id
+            profile_first_completed_campaign_id: request.body.profile_first_completed_campaign_id,
+            save_to: request.query.save_to
           };
           handleUserResponse(doc, requestData);
         }, function(err) {
@@ -109,16 +128,18 @@ function onDocumentFound(doc, phone, campaignConfig) {
  *   Data from the user's request
  */
 function handleUserResponse(doc, data) {
-  if (!doc.photo) {
+  var override = data.save_to;
+
+  if (override === 'photo' || (!override && !doc.photo)) {
     receivePhoto(doc, data);
   }
-  else if (!doc.caption) {
+  else if (override === 'caption' || (!override && !doc.caption)) {
     receiveCaption(doc, data);
   }
-  else if (!doc.quantity) {
+  else if (override === 'quantity' || (!override && !doc.quantity)) {
     receiveQuantity(doc, data);
   }
-  else if (!doc.why_important) {
+  else if (override === 'why_important' || (!override && !doc.why_important)) {
     receiveWhyImportant(doc, data);
   }
 }

--- a/app/lib/reportback/index.js
+++ b/app/lib/reportback/index.js
@@ -31,6 +31,9 @@ else {
  * POST /reportback/:campaign
  *
  * Query Params:
+ *   config_override - (optional) use the config taggedwith this config_override.
+ *     By default, we use the campaign value in the URL to find the config with
+ *     the matching endpoint value.
  *   save_to - (optional) force this response to save to the specified field
  *     Valid options: photo, caption, quantity, why_important
  *
@@ -42,16 +45,19 @@ else {
  *     Commons campaign the user has completed
  */
 router.post('/:campaign', function(request, response) {
-  var campaign
-    , campaignConfig
+  var campaignConfig
     , phone
     , requestData
     , i
     ;
   
-  // Check that we have a config setup for this campaign
-  campaign = request.params.campaign;
-  campaignConfig = app.getConfig(app.ConfigName.REPORTBACK, campaign, 'endpoint');
+  // Get the config either from the override or the campaign value in the URL
+  if (request.query.config_override) {
+    campaignConfig = app.getConfig(app.ConfigName.REPORTBACK, request.query.config_override, 'config_override');
+  }
+  else {
+    campaignConfig = app.getConfig(app.ConfigName.REPORTBACK, request.params.campaign, 'endpoint');
+  }
 
   if (typeof campaignConfig !== 'undefined') {
     phone = request.body.phone;

--- a/app/lib/reportback/reportbackConfigModel.js
+++ b/app/lib/reportback/reportbackConfigModel.js
@@ -13,6 +13,10 @@ var rbSchema = new mongoose.Schema({
   // Mobile Commons campaign ID to opt user out of
   campaign_optout_id: Number,
 
+  // Hacky - use this to id a secondary reportback flow when there are multiple
+  // flows for a single endpoint value
+  config_override: String,
+
   // Resource name used as endpoint in URL
   endpoint: String,
 


### PR DESCRIPTION
#### What's this PR do?

When requests are made to `POST /reportback/:campaign_name`, we can now add a `save_to` query parameter. This allows us to specify what reportback field the user response should be saved into - even if it's already got a value in the reportback doc.

ex: `POST /reportback/:campaign_name?save_to=quantity`

The valid `save_to` values are:
- photo
- caption
- quantity
- why_important

**Update!** We also need to add a `config_override` query param to the request calls for this second custom reportback. This was needed because the user reportback docs that exist are already keyed up with the original campaign `endpoint` value. In order to distinguish between the original reportback config and the new one we'll create, we'll specify it by this `config_override`. Am I making sense? It's the end of the day and I just wanna get this thing done and out the door.
#### Where should the reviewer start?

Requests come in through the `router.post`. The `save_to` value is added to the custom object that gets passed to `handleUserResponse()`. And then the logic in there determines how it should process the response and save it.
#### What was tested?

I manually tested two scenarios on my local setup:
1. User filled out multiple fields for the reportback - photo, caption, quantity. Then using `?save_to=`, I verified that I could overwrite the values for each
2. User submitted only a photo. Typically, the next response should be put into caption, but using `?save_to=quantity` was able to send the next value into the `quantity` field.
#### Any background context?

This is primarily needed right now for a custom reportback for users who have submitted a photo but didn't get to complete the rest of the reportback afterwards.
