### PR TITLE
Adds Northstar Client, queries for existing Northstar ID

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -104,27 +104,24 @@ CampaignBotController.prototype.chatbot = function(req, res) {
 CampaignBotController.prototype.createUserAndPostSignup = function(req, res) {
   var self = this;
 
-  app.locals.northstarClient.Users.get('id', req.user_id).then(function(user) {
-
-    dbUsers.create({
-
-      _id: req.user_id,
-      mobile: req.user_mobile,
-      first_name: user.firstName,
-      email: user.email,
-      phoenix_id: user.drupalID,
-      campaigns: {}
-
-    }).then(function (userDoc) {
-
+  app.locals.northstarClient.Users.get('id', req.user_id)
+    .then(function(user) {
+      const userFields = {
+        _id: req.user_id,
+        mobile: req.user_mobile,
+        first_name: user.firstName,
+        email: user.email,
+        phoenix_id: user.drupalID,
+        campaigns: {} ,   
+      };
+      return dbUsers.create(userFields);
+    })
+    .then(function (userDoc) {
       self.user = userDoc;
       logger.debug('%s created user', self.loggerPrefix(req));
       self.postSignup(req, res);
-
-    });
-
-  }, function(err) {self.handleError(req, res, err)});
-
+    })
+    .catch(function(err) {self.handleError(req, res, err)});
 }
 
 /**

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -104,24 +104,27 @@ CampaignBotController.prototype.chatbot = function(req, res) {
 CampaignBotController.prototype.createUserAndPostSignup = function(req, res) {
   var self = this;
 
-  var newUser = {
-    _id: req.user_id,
-    mobile: req.user_mobile,
-    campaigns: {}
-  };
+  app.locals.northstarClient.Users.get('id', req.user_id).then(function(user) {
 
-  dbUsers.create(newUser, function (err, userDoc) {
+    dbUsers.create({
 
-    if (err) {
-      return self.handleError(req, res, err);
-    }
+      _id: req.user_id,
+      mobile: req.user_mobile,
+      first_name: user.firstName,
+      email: user.email,
+      phoenix_id: user.drupalID,
+      campaigns: {}
 
-    self.user = userDoc;
-    logger.debug('%s created user', self.loggerPrefix(req));
+    }).then(function (userDoc) {
 
-    self.postSignup(req, res);
+      self.user = userDoc;
+      logger.debug('%s created user', self.loggerPrefix(req));
+      self.postSignup(req, res);
 
-  });
+    });
+
+  }, function(err) {self.handleError(req, res, err)});
+
 }
 
 /**

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -10,6 +10,10 @@ var schema = new mongoose.Schema({
 
   mobile: {type: String, index: true},
 
+  phoenix_id: Number,
+
+  email: String,
+
   first_name: String,
 
   supports_mms: {type: Boolean, default: false},

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git+https://github.com/DoSomething/gambit.git"
   },
   "dependencies": {
+    "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "body-parser": "^1.9.2",
     "connect-multiparty": "1.1.0",
     "count-von-count": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,8 @@ var http = require('http');
 var logger = rootRequire('lib/logger');
 var phoenix = rootRequire('lib/phoenix')();
 
+const NorthstarClient = require('@dosomething/northstar-js');
+
 // Default is 5. Increasing # of concurrent sockets per host.
 http.globalAgent.maxSockets = 100;
 
@@ -38,4 +40,9 @@ smsConfigsLoader(function() {
   app.listen(port, function() {
     logger.log('info', 'Express server listening on port %d in %s mode...\n\n', port, app.settings.env);
   });
+});
+
+app.locals.northstarClient = new NorthstarClient({
+  baseURI: process.env.DS_REST_API_BASEURI,
+  apiKey: process.env.DS_REST_API_KEY,
 });


### PR DESCRIPTION
#### What's this PR do?

Begins adding Northstar support into the CampaignBot prototype.
- Stores a `NorthstarClient` instance to `app.locals.northstarClient`
- Modifies local `users` document creation for a Northstar ID (based on the Mobile Commons `northstar_id` Profile Field) to query Northstar to store our User's First Name, Email, and Phoenix ID 
#### How should this be reviewed?
- Run `npm install` to add Northstar JS
- Delete your `users` collection locally, and then test posting to the CampaignBot with your northstar id set as a `profile_northstar_id`. Verify a user document is created with your mobile, email, first name, and Phoenix ID.
#### Any background context you want to provide?
- Storing Phoenix ID will make it easy to post Signups and Reportbacks to Phoenix for now, since Northstar POST Signup/Reportback doesn't support a `user` input parameter (https://github.com/DoSomething/northstar/issues/429)
- TODO: Pin package.json to new Northstar JS release (or just always leave as breaking for now until development is finished) 
- TODO: If we don't have an incoming `northstar_id`, check to see if Northstar User exists for mobile (which it probably won't). If not, create new Northstar User and corresponding Gambit User doc
- TODO We'll also want use the `northstarClient` to query for the current User's Signups for a given campaign, using [`app.locals.northstarClient.Signups.index`](https://github.com/DoSomething/northstar-js/blob/b4a7b985b6681ddac38e82dc53019b65c6488574/lib/northstar-endpoint-signups.js#L33)
#### Relevant tickets
#606 - begins Northstar integration
#### Checklist
- [x] Tested on staging.
