### PR TITLE
Updates Mongoose and replaces callbacks with promises

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -1,16 +1,16 @@
 "use strict";
 
-var logger = rootRequire('lib/logger');
-var mobilecommons = rootRequire('lib/mobilecommons');
-var phoenix = rootRequire('lib/phoenix')();
-var helpers = rootRequire('lib/helpers');
+const logger = rootRequire('lib/logger');
+const mobilecommons = rootRequire('lib/mobilecommons');
+const phoenix = rootRequire('lib/phoenix')();
+const helpers = rootRequire('lib/helpers');
 
-var connOps = rootRequire('config/connectionOperations');
-var dbRbSubmissions = require('../models/campaign/ReportbackSubmission')(connOps);
-var dbSignups = require('../models/campaign/Signup')(connOps);
-var dbUsers = require('../models/User')(connOps);
+const connOps = rootRequire('config/connectionOperations');
+const dbRbSubmissions = require('../models/campaign/ReportbackSubmission')(connOps);
+const dbSignups = require('../models/campaign/Signup')(connOps);
+const dbUsers = require('../models/User')(connOps);
 
-var CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
+const CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
 
 /**
  * CampaignBotController

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -77,7 +77,7 @@ CampaignBotController.prototype.loadUserAndSignup = function(req, res) {
   this.debug(req, 'loadUserAndSignup');
   
   dbUsers
-    .findOne({ '_id': req.user_id })
+    .findById(req.user_id)
     .exec()
     .then(userDoc => {
       if (!userDoc) {
@@ -139,7 +139,7 @@ CampaignBotController.prototype.loadSignup = function(req, res, signupId) {
   // Signup ID to our user's current dbSignups in user.campaigns
 
   dbSignups
-    .findOne({ '_id': signupId })
+    .findById(signupId)
     .exec()
     .then(signupDoc => {
       if (!signupDoc) {
@@ -180,7 +180,7 @@ CampaignBotController.prototype.loadReportbackSubmission = function(req, res) {
 
   const rbSubmissionId = this.signup.draft_reportback_submission;
   dbRbSubmissions
-    .findOne({ '_id': rbSubmissionId })
+    .findById(rbSubmissionId)
     .exec()
     .then(reportbackSubmissionDoc => {
       this.reportbackSubmission = reportbackSubmissionDoc;

--- a/config/connectionOperations.js
+++ b/config/connectionOperations.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+mongoose.Promise = global.Promise;
 
 var connectionOperations;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mobilecommons": ">=0.0.4",
     "mocha": "1.20.x",
     "mocha-lcov-reporter": "0.0.1",
-    "mongoose": "~3.8.8",
+    "mongoose": "~4.6.1",
     "mysql": "2.1.x",
     "newrelic": "^1.28.3",
     "node-request-retry": "^1.0.0",


### PR DESCRIPTION
#### What's this PR do?
- Updates Mongoose to 4.6.1
- Replaces `findOne` calls with `findById`
- Switches `create`, `findById`, `save` callbacks with promises [ref](http://eddywashere.com/blog/switching-out-callbacks-with-promises-in-mongoose/)
- Abstracts the `dbUsers.findOne` call into a `loadUserAndSignup` function
- Renames `continueReportbackSubmission` as `loadReportbackSubmission`
- Renames `startReportbackSubmission` as `createReportbackSubmission`
- Removes `self = this` noise
#### How should this be reviewed?

Test CampaignBot locally, on staging upon deploy.
#### Any background context you want to provide?

Next up, adding relevant Phoenix JS and Northstar JS networking calls.
#### Checklist
- [x] Tested on staging.
