### PR TITLE
Adds Phoenix JS, posts Campaign Signup to Phoenix

### DIFF
--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -5,8 +5,7 @@ var mongoose = require('mongoose');
 
 var schema = new mongoose.Schema({
 
-// We'll want to add this back in once we start integrate Signups API
-//  _id: {type: Number, index: true},
+  _id: {type: Number, index: true},
 
   user: {type: String, index: true},
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
+    "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
     "body-parser": "^1.9.2",
     "connect-multiparty": "1.1.0",
     "count-von-count": "^1.0.0",

--- a/server.js
+++ b/server.js
@@ -5,12 +5,10 @@ global.rootRequire = function(name) {
   return require(__dirname + '/' + name);
 }
 
-var express = require('express');
-var path = require('path');
-var http = require('http');
-var logger = rootRequire('lib/logger');
-var phoenix = rootRequire('lib/phoenix')();
-
+const express = require('express');
+const http = require('http');
+const logger = rootRequire('lib/logger');
+const phoenix = rootRequire('lib/phoenix')();
 const NorthstarClient = require('@dosomething/northstar-js');
 const PhoenixClient = require('@dosomething/phoenix-js');
 
@@ -31,17 +29,9 @@ phoenix.userLogin(
  */
 app = express();
 
-var appConfig = require('./config')();
-var router = require('./api/router');
-var smsConfigsLoader = require('./config/smsConfigsLoader');
-
-// Retrieves all SMS config files before starting server.
-smsConfigsLoader(function() {
-  var port = process.env.PORT || 5000;
-  app.listen(port, function() {
-    logger.log('info', 'Express server listening on port %d in %s mode...\n\n', port, app.settings.env);
-  });
-});
+const appConfig = require('./config')();
+const router = require('./api/router');
+const smsConfigsLoader = require('./config/smsConfigsLoader');
 
 app.locals.northstarClient = new NorthstarClient({
   baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
@@ -53,3 +43,13 @@ app.locals.phoenixClient = new PhoenixClient({
   username: process.env.DS_PHOENIX_API_USERNAME,
   password: process.env.DS_PHOENIX_API_PASSWORD,
 });
+
+// Retrieves all SMS config files before starting server.
+smsConfigsLoader(() => {
+  const port = (process.env.PORT || 5000);
+  app.listen(port, () => {
+    logger.info(`Gambit is listening, port:${port} env:${process.env.NODE_ENV}.`);
+  });
+});
+
+

--- a/server.js
+++ b/server.js
@@ -12,13 +12,14 @@ var logger = rootRequire('lib/logger');
 var phoenix = rootRequire('lib/phoenix')();
 
 const NorthstarClient = require('@dosomething/northstar-js');
+const PhoenixClient = require('@dosomething/phoenix-js');
 
 // Default is 5. Increasing # of concurrent sockets per host.
 http.globalAgent.maxSockets = 100;
 
 phoenix.userLogin(
-  process.env.DS_CONTENT_API_USERNAME,
-  process.env.DS_CONTENT_API_PASSWORD,
+  process.env.DS_PHOENIX_API_USERNAME,
+  process.env.DS_PHOENIX_API_PASSWORD,
   function(err, response, body) {
     if (response && response.statusCode == 200) {
       logger.info('Successfully logged in to %s Phoenix API.', process.env.NODE_ENV);
@@ -43,6 +44,12 @@ smsConfigsLoader(function() {
 });
 
 app.locals.northstarClient = new NorthstarClient({
-  baseURI: process.env.NORTHSTAR_API_BASEURI,
-  apiKey: process.env.NORTHSTAR_API_KEY,
+  baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
+  apiKey: process.env.DS_NORTHSTAR_API_KEY,
+});
+
+app.locals.phoenixClient = new PhoenixClient({
+  baseURI: process.env.DS_PHOENIX_API_BASEURI,
+  username: process.env.DS_PHOENIX_API_USERNAME,
+  password: process.env.DS_PHOENIX_API_PASSWORD,
 });

--- a/server.js
+++ b/server.js
@@ -43,6 +43,6 @@ smsConfigsLoader(function() {
 });
 
 app.locals.northstarClient = new NorthstarClient({
-  baseURI: process.env.DS_REST_API_BASEURI,
-  apiKey: process.env.DS_REST_API_KEY,
+  baseURI: process.env.NORTHSTAR_API_BASEURI,
+  apiKey: process.env.NORTHSTAR_API_KEY,
 });


### PR DESCRIPTION
#### What's this PR do?
- Adds `phoenix-js` - pulls from `master` branch for now 🔥 
- Adds an authorized `phoenixClient` to our `app.locals` (refs #627)
- Modifies `/campaigns/models/Signup.js` to store `_id` as Number instead of an ObjectId
- Posts Signup to Phoenix and creates a document in the Signups collection with newly inserted Signup ID
#### How should this be reviewed?
- Delete any existing `signups` documents or `user.campaigns` properties -- you'll get a Cast error
- Post to CampaignBot for a campaign you're not signed up for
- To remove signup, you'll need to remove the Signup from Phoenix using the webform (logged in as admin), but will also need to modify the `user.campaigns` property in your Gambit `users` collection to clear out the Signup stored for the Campaign.
#### Any background context you want to provide?

I've been debating on whether we should write the Signup anyway, regardless of whether the Phoenix POST succeeds or fails. Returning an error (instead of keeping track of our own Signup ObjectID) seemed like the simpler approach, but keeping our own cache also has its benefits if Phoenix is down 🚑 
#### Relevant tickets
#606, #549 https://github.com/DoSomething/quicksilver-api/issues/98
#### Checklist
- [x] Set new environment variables (`DS_NORTHSTAR_API_BASEURI`, `DS_NORTHSTAR_API_KEY`,`DS_PHOENIX_API_BASEURI`,  `DS_PHOENIX_API_USERNAME`, `DS_PHOENIX_API_PASSWORD`, `DS_API_POST_SOURCE`)
- [x] Test on staging.
