### PR TITLE
CampaignBot: post Reportback to Phoenix API 

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -47,17 +47,17 @@ function CampaignBotController(campaignId) {
  */
 CampaignBotController.prototype.chatbot = function(req, res) {
   if (!this.bot) {
-    return this.handleError(req, res, 'self.bot undefined');
+    return this.handleError(req, res, 'chatbot.bot undefined');
   }
   if (!this.campaign) {
-    return this.handleError(req, res, 'self.campaign undefined');
+    return this.handleError(req, res, 'chatbot.campaign undefined');
   }
   if (!this.mobileCommonsConfig) {
-    return this.handleError(req, res, 'self.mobileCommonsConfig undefined');
+    return this.handleError(req, res, 'chatbot.mobileCommonsConfig undefined');
   }
   // This seems like it should move into router.js (or policies dir)
   if (!req.user_id) {
-    return this.handleError(req, res, 'req.user_id undefined');
+    return this.handleError(req, res, 'chatbot.req.user_id undefined');
   }
 
   this.debug(req, `incoming_message_url:${req.incoming_message}`);
@@ -145,7 +145,7 @@ CampaignBotController.prototype.loadSignup = function(req, res, signupId) {
         // Edge case where our cached Signup ID in user.campaigns not found
         // Could potentially lookup campaign/user in dbSignups to check for any
         // Signup document to use, but for now let's log and assume wont happen.
-        return this.handleError(req, res, 'signupDoc not found _id:%s', signupId);
+        return this.handleError(req, res, 'loadSignup no doc _id:%s', signupId);
       }
       this.signup = signupDoc;
       this.debug(req, `loaded signup:${signupDoc.id}`);
@@ -343,8 +343,6 @@ CampaignBotController.prototype.collectWhyParticipated = function(req, res, prom
 CampaignBotController.prototype.postReportback = function(req, res) {
   this.debug(req, 'postReportback');
 
-  const dateSubmitted = Date.now();
-
   const postData = {
     source: process.env.DS_API_POST_SOURCE,
     uid: this.user.phoenix_id,
@@ -359,19 +357,38 @@ CampaignBotController.prototype.postReportback = function(req, res) {
   return app.locals.phoenixClient.Campaigns
     .reportback(this.campaignId, postData)
     .then(reportbackId => {
-      this.debug(req, `upsert reportback:${reportbackId}`);
-      this.reportbackSubmission.submitted_at = dateSubmitted;
-      return this.reportbackSubmission.save();
+      return this.onReportbackSuccess(req, res, reportbackId);
     })
+    .catch(err => {
+      this.reportbackSubmission.failed_at = Date.now();
+      this.reportbackSubmission.save();
+      return this.handleError(req, res, `postReportback ${err}`);
+    });
+}
+
+/**
+ * Handles successful Reportback POST request.
+ * @param {object} req - Express request
+ * @param {object} res - Express response
+ * @param {number} rbid - Return reportback id
+ */
+CampaignBotController.prototype.onReportbackSuccess = function(req, res, rbid) {
+  this.debug(req, `onReportbackSuccess reportback:${rbid}`);
+
+  const dateSubmitted = Date.now();
+  this.reportbackSubmission.submitted_at = dateSubmitted;
+  this.signup.reportback = rbid;
+  this.signup.total_quantity_submitted = this.reportbackSubmission.quantity;
+  this.signup.updated_at = dateSubmitted;
+  // Unset draft so next time user returns to this campaign, we create a new
+  // reportback submission.
+  this.signup.draft_reportback_submission = undefined;
+  return this.reportbackSubmission
+    .save()
     .then(() => {
-      this.debug(req, `saved submitted_at:${dateSubmitted}`);
-      this.signup.total_quantity_submitted = this.reportbackSubmission.quantity;
-      this.signup.updated_at = dateSubmitted;
-      this.signup.draft_reportback_submission = undefined;
       return this.signup.save();
     })
     .then(() => {
-      this.debug(req, `saved signup.quantity:${this.signup.total_quantity_submitted}`);
       return this.sendMessage(req, res, this.bot.msg_menu_completed);
     });
 }
@@ -487,7 +504,7 @@ CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
   var optInPath = this.mobileCommonsConfig.oip_chat;
 
   if (!optInPath) {
-    return this.handleError(req, res);
+    return this.handleError(req, res, 'sendMessage !optInPath');
   }
 
   mobilecommons.chatbot({phone: this.user.mobile}, optInPath, msgTxt);
@@ -500,10 +517,8 @@ CampaignBotController.prototype.sendMessage = function(req, res, msgTxt) {
  * @param {object} res - Express response
  * @param {object} error
  */
-CampaignBotController.prototype.handleError = function(req, res, error) {
-  if (error) {
-    logger.error('%s handleError:' + error, this.loggerPrefix(req));
-  }
+CampaignBotController.prototype.handleError = function(req, res, errorMsg) {
+  logger.error(`${this.loggerPrefix(req)} ${errorMsg}`);
   return res.sendStatus(500);
 }
 
@@ -519,6 +534,7 @@ CampaignBotController.prototype.loggerPrefix = function(req) {
 /**
  * Calls logger with CampaignBot prefix
  * @param {object} req - Express request
+ * @param {object} message - Message to log
  * @return {string}
  */
 CampaignBotController.prototype.debug = function(req, debugMsg) {

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -345,11 +345,24 @@ CampaignBotController.prototype.postReportback = function(req, res) {
 
   const dateSubmitted = Date.now();
 
-  // @todo Post Reportback to DS API
+  const postData = {
+    source: process.env.DS_API_POST_SOURCE,
+    uid: this.user.phoenix_id,
+    quantity: this.reportbackSubmission.quantity,
+    caption: this.reportbackSubmission.caption,
+    file_url: this.reportbackSubmission.image_url,
+  };
+  if (this.reportbackSubmission.why_participated) {
+    postData.why_participated = this.reportbackSubmission.why_participated;
+  }
 
-  this.reportbackSubmission.submitted_at = dateSubmitted;
-  return this.reportbackSubmission
-    .save()
+  return app.locals.phoenixClient.Campaigns
+    .reportback(this.campaignId, postData)
+    .then(reportbackId => {
+      this.debug(req, `upsert reportback:${reportbackId}`);
+      this.reportbackSubmission.submitted_at = dateSubmitted;
+      return this.reportbackSubmission.save();
+    })
     .then(() => {
       this.debug(req, `saved submitted_at:${dateSubmitted}`);
       this.signup.total_quantity_submitted = this.reportbackSubmission.quantity;

--- a/api/models/campaign/ReportbackSubmission.js
+++ b/api/models/campaign/ReportbackSubmission.js
@@ -19,7 +19,9 @@ var schema = new mongoose.Schema({
 
   why_participated: String,
 
-  submitted_at: Date
+  submitted_at: Date,
+
+  failed_at: Date
 
 })
 

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -13,6 +13,8 @@ var schema = new mongoose.Schema({
 
   created_at: {type: Date, default: Date.now},
 
+  reportback: Number,
+
   // If user is in the middle of a Reportback Submission, we store its ID 
   // for easy lookup.
   draft_reportback_submission: String,


### PR DESCRIPTION
#### What's this PR do?
- Implements Phoenix JS `Campaigns.reportback(campaignId, data)` in our `CampaignBotController.postReportback(req, res)` function to post data stored in current user's`reportbackSubmission` to DS API
- Adds number property`Signup.reportback` to store the returned Reportback id from Phoenix API
- Adds date property `ReportbackSubmission.failed_at` to track Reportback Submissions that have failed
#### How should this be reviewed?
- Report back to CampaignBot, check Thor for its existence
- Verify `failed_at` works as expected if you set an invalid `DS_PHOENIX_API_BASEURI` environment variable
#### Any background context you want to provide?

The good and bad thing here is that if a User texts back into the Campaign after a Reportback is failed, we'll try to post it again.
#### Relevant tickets
#606
#### Checklist
- [x] Tested on staging.
