### PR TITLE
Adds staff-only command to clear Signup cache

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -254,8 +254,9 @@ class CampaignBotController {
     }
 
     const input = helpers.getFirstWord(req.incoming_message);
+    const isCommand = input && input.toUpperCase() === cmdClear.toUpperCase();
 
-    return ( input && input.toUpperCase() === cmdClear.toUpperCase() );
+    return isCommand;
   }
 
   /**

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -246,13 +246,15 @@ class CampaignBotController {
   }
 
   /**
-   * Returns whether incomingMessage should begin a Reportback conversation.
-   * @param {string} incomingMessage
+   * Returns whether incoming Express req begins a Reportback conversation.
+   * @param {object} req - Express request
    * @return {bool}
    */
-  isCommandReportback(incomingMessage) {
-    const firstWord = helpers.getFirstWord(incomingMessage);
-    return ( firstWord && firstWord.toUpperCase() === CMD_REPORTBACK );
+  isCommandReportback(req) {
+    const firstWord = helpers.getFirstWord(req.incoming_message);
+    if (!firstWord) return false;
+
+    return firstWord.toUpperCase() === CMD_REPORTBACK.toUpperCase();
   }
 
   /**

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -186,7 +186,9 @@ class CampaignBotController {
         data.total_quantity_submitted = currentSignup.reportback.quantity;
       }
 
-      return app.locals.db.signups.create(data);
+      return app.locals.db.signups
+        .findOneAndUpdate({ _id: data._id }, data, { upsert: true })
+        .exec();
     })
     .then(signupDoc => {
       this.debug(req, `created signupDoc:${signupDoc._id.toString()}`);

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -262,6 +262,8 @@ class CampaignBotController {
    * @return {object}
    */
   loadCurrentSignup(req, id) {
+    this.debug(req, `loadCurrentSignup:${id}`);
+
     if (this.isCommandClearCache(req)) {
       this.debug(req, `isCommandClearCache`);
 

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -14,6 +14,8 @@ var schema = new mongoose.Schema({
 
   email: String,
 
+  role: String,
+
   first_name: String,
 
   supports_mms: {type: Boolean, default: false},

--- a/api/router.js
+++ b/api/router.js
@@ -115,7 +115,7 @@ function campaignBot(req, res) {
         return controller.continueReportbackSubmission(req);
       }
 
-      if (controller.isCommandReportback(req.incoming_message)) {
+      if (controller.isCommandReportback(req)) {
         return controller.createReportbackSubmission(req);
       }
 

--- a/api/router.js
+++ b/api/router.js
@@ -101,6 +101,14 @@ function campaignBot(req, res) {
       controller.debug(req, `loaded user:${user._id}`);
 
       req.user = user;
+
+      if (controller.isCommandClearCache(req)) {
+        req.user.campaigns = {};
+        logger.info(`${controller.loggerPrefix(req)} cleared user.campaigns`);
+
+        return controller.getCurrentSignup(req); 
+      }
+
       const signupId = user.campaigns[req.campaign_id];
 
       if (signupId) return controller.loadCurrentSignup(req, signupId);

--- a/api/router.js
+++ b/api/router.js
@@ -77,11 +77,13 @@ router.post('/v1/chatbot/sync', function(request, response) {
 function campaignBot(req, res) {
   req.campaign_id = req.query.campaign;
   const controller = app.locals.campaignBotController;
+  controller.debug(req, `msg:${req.incoming_message} img:${req.incoming_image_url}`);
 
   req.campaign = app.getConfig(
     app.ConfigName.CAMPAIGNS,
     req.campaign_id
   );
+
   req.mobilecommons_campaign = req.campaign.staging_mobilecommons_campaign;
   if (process.env.NODE_ENV === 'production') {
     req.mobilecommons_campaign = req.campaign.current_mobilecommons_campaign;
@@ -102,7 +104,7 @@ function campaignBot(req, res) {
       const signupId = user.campaigns[req.campaign_id];
 
       if (signupId) {
-        controller.debug(req, `loadSignup:${signupId}`);
+        controller.debug(req, `loadCurrentSignup:${signupId}`);
         return controller.loadCurrentSignup(req, signupId);
       }
 

--- a/api/router.js
+++ b/api/router.js
@@ -103,10 +103,7 @@ function campaignBot(req, res) {
       req.user = user;
       const signupId = user.campaigns[req.campaign_id];
 
-      if (signupId) {
-        controller.debug(req, `loadCurrentSignup:${signupId}`);
-        return controller.loadCurrentSignup(req, signupId);
-      }
+      if (signupId) return controller.loadCurrentSignup(req, signupId);
 
       return controller.getCurrentSignup(req);
     })

--- a/api/router.js
+++ b/api/router.js
@@ -111,7 +111,9 @@ function campaignBot(req, res) {
 
       const signupId = user.campaigns[req.campaign_id];
 
-      if (signupId) return controller.loadCurrentSignup(req, signupId);
+      if (signupId) {
+        return controller.loadCurrentSignup(req, signupId);
+      }
 
       return controller.getCurrentSignup(req);
     })


### PR DESCRIPTION
#### What's this PR do?
- Checks for whether current User has `role` set to `'staff'` or `'admin`'  and has texted in a Clear Cache command. If true, delete the cached Signup model and call `getCurrentSignup(req)` 
#### How should this be reviewed?

Test by locally modifying your User's `role` property in the `users` collection, and text in clear cache keyword (set by `GAMBIT_CMD_CLEAR_CACHE` environment variable). 
- Text Clear Cache keyword when a Signup exists in Phoenix, confirm existing Signup is cached to Gambit Signups collection
- Remove signup from Phoenix admin UI, text Clear Cache keyword and confirm new Signup ID is created in Phoenix and cached to Signups collection
#### Any background context you want to provide?

For internal testing of Signup flow to avoid API error code 500 returned when resubmitting a Signup for a a given Campaign and User.
#### Relevant tickets
- Fixes #634
- https://github.com/DoSomething/northstar-js/pull/27
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
