### PR TITLE
Lint CampaignBotController

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,16 @@
+---
+  extends: "@dosomething/eslint-config"
+  globals:
+    app: true
+    rootRequire: true
+  parserOptions:
+    # Node requires 'use strict' to use built-in ES6 compatibility.
+    # Use script source type, so lint doesn't throw error:
+    # 'use strict' is unnecessary inside of modules.
+    sourceType: "script"
+  rules:
+    # We don't use babel here, so require 'use strict'.
+    # See https://git.io/vr6I0.
+    strict:
+      - 2
+      - "global"

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -1,16 +1,15 @@
-"use strict";
+'use strict';
 
 /**
  * Imports.
  */
 const logger = rootRequire('lib/logger');
-const mobilecommons = rootRequire('lib/mobilecommons');
 const helpers = rootRequire('lib/helpers');
 
 /**
  * Setup.
  */
-const CMD_REPORTBACK = (process.env.GAMBIT_CMD_REPORTBACK || 'P');
+const CMD_REPORTBACK = process.env.GAMBIT_CMD_REPORTBACK || 'P';
 
 /**
  * CampaignBotController.
@@ -24,11 +23,6 @@ class CampaignBotController {
    */
   constructor(campaignBotId) {
     this.bot = app.getConfig(app.ConfigName.CAMPAIGNBOTS, campaignBotId);
-    logger.info(`CampaignBotController loaded campaignBot:${campaignBotId}`);
-
-    if (!this.bot) {
-      return this.error(req, `CampaignBot not found for id:${campaignBotId}`);
-    }
   }
 
   /**
@@ -45,39 +39,41 @@ class CampaignBotController {
     if (req.query.start || ask) {
       return this.renderResponseMessage(req, this.bot[`msg_ask_${property}`]);
     }
-    
+
     let input = req.incoming_message;
 
+    // Validate input received for our given Reportback property.
     if (property === 'quantity') {
-      if (helpers.hasLetters(input) || !parseInt(input)) {
+      if (helpers.hasLetters(input) || !Number(input)) {
         return this.renderResponseMessage(req, this.bot.msg_invalid_quantity);
       }
-      input = parseInt(input);
-    }
-    else if (property === 'photo') {
+      input = Number(input);
+    } else if (property === 'photo') {
       input = req.incoming_image_url;
       if (!input) {
         return this.renderResponseMessage(req, this.bot.msg_no_photo_sent);
       }
     }
 
-    req.signup.draft_reportback_submission[property] = input;
+    const submission = req.signup.draft_reportback_submission;
+    submission[property] = input;
 
-    return req.signup.draft_reportback_submission
+    return submission
       .save()
       .then(() => {
         this.debug(req, `saved ${property}:${input}`);
-        switch(property) {
-          case 'quantity':
-            return this.renderResponseMessage(req, this.bot.msg_ask_photo);
-          case 'photo':
-            return this.renderResponseMessage(req, this.bot.msg_ask_caption);
-          case 'caption':
-            // @todo Only ask for why when first reportback.
-            return this.renderResponseMessage(req, this.bot.msg_ask_why_participated);
-          default:
-            return this.postReportback(req);
+
+        if (property === 'quantity') {
+          return this.renderResponseMessage(req, this.bot.msg_ask_photo);
+        } else if (property === 'photo') {
+          return this.renderResponseMessage(req, this.bot.msg_ask_caption);
+        } else if (property === 'caption') {
+          // TODO: Only ask for why when first reportback.
+          return this.renderResponseMessage(req, this.bot.msg_ask_why_participated);
         }
+
+        // If we made it this far, we're done collecting and ready to submit.
+        return this.postReportback(req);
       });
   }
 
@@ -89,14 +85,14 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = ( req.query.start || false );
+    const ask = req.query.start || false;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);
     }
     if (!submission.photo) {
       return this.collectReportbackProperty(req, 'photo', ask);
-    } 
+    }
     if (!submission.caption) {
       return this.collectReportbackProperty(req, 'caption', ask);
     }
@@ -122,16 +118,18 @@ class CampaignBotController {
     return app.locals.db.reportbackSubmissions
       .create({
         campaign: req.campaign_id,
-        user: req.user_id, 
+        user: req.user_id,
       })
       .then(reportbackSubmission => {
         this.debug(req, `created :${reportbackSubmission._id.toString()}`);
-        req.signup.draft_reportback_submission = reportbackSubmission._id;
 
-        return req.signup.save();
+        const currentSignup = req.signup;
+        currentSignup.draft_reportback_submission = reportbackSubmission._id;
+
+        return currentSignup.save();
       })
       .then(() => {
-        this.debug(req, `updated signup:${req.signup._id.toString()}`)
+        this.debug(req, `updated signup:${req.signup._id.toString()}`);
 
         return this.collectReportbackProperty(req, 'quantity', true);
       });
@@ -170,13 +168,14 @@ class CampaignBotController {
       if (!signups.length) {
         return this.postSignup(req);
       }
-      
+
       // TODO: Loop through signups to find signup where campaign_run.current.
       // Hardcoded to first result for now.
       const currentSignup = signups[0];
       this.debug(req, `currentSignup.id:${currentSignup.id}`);
+
       const data = {
-        _id: parseInt(currentSignup.id),
+        _id: Number(currentSignup.id),
         user: req.user_id,
         campaign: req.campaign_id,
         created_at: currentSignup.createdAt,
@@ -185,24 +184,24 @@ class CampaignBotController {
         draft_reportback_submission: null,
       };
       if (currentSignup.reportback) {
-        data.reportback = parseInt(currentSignup.reportback.id);
+        data.reportback = Number(currentSignup.reportback.id);
         data.total_quantity_submitted = currentSignup.reportback.quantity;
       }
 
       return app.locals.db.signups
-        .findOneAndUpdate({ _id: data._id }, data, { upsert: true, new: true  })
+        .findOneAndUpdate({ _id: data._id }, data, { upsert: true, new: true })
         .exec();
     })
-    .then(signupDoc => {
+    .then((signupDoc) => {
       this.debug(req, `created signupDoc:${signupDoc._id.toString()}`);
+
       signup = signupDoc;
-      req.user.campaigns[req.campaign_id] = signupDoc._id;
-      req.user.markModified('campaigns');
-      return req.user.save();
+      const currentUser = req.user;
+      currentUser.campaigns[req.campaign_id] = signupDoc._id;
+      currentUser.markModified('campaigns');
+      return currentUser.save();
     })
-    .then(() => {
-      return signup;
-    });
+    .then({ signup });
   }
 
   /**
@@ -215,8 +214,8 @@ class CampaignBotController {
       .get('id', id)
       .then(user => {
         if (!user) {
-          // TODO: Create new User
-          return;
+          // TODO: Edge case where User ID saved to Mobile Commons profile
+          // is not found in DS API GET request.
         }
         const data = {
           _id: id,
@@ -225,12 +224,12 @@ class CampaignBotController {
           email: user.email,
           phoenix_id: user.drupalID,
           role: user.role,
-          campaigns: {},         
-        }
+          campaigns: {},
+        };
         return app.locals.db.users
           .findOneAndUpdate({ _id: data._id }, data, {
             upsert: true,
-            new: true 
+            new: true,
           });
       });
   }
@@ -241,7 +240,7 @@ class CampaignBotController {
    * @return {bool}
    */
   isCommandClearCache(req) {
-    const cmdClear =  process.env.GAMBIT_CMD_CLEAR_CACHE;
+    const cmdClear = process.env.GAMBIT_CMD_CLEAR_CACHE;
 
     if (!cmdClear) return false;
 
@@ -286,12 +285,13 @@ class CampaignBotController {
       .exec()
       .then(signup => {
         if (!signup) {
-          this.debug(req, `signup not found for id:${id}`)
+          this.debug(req, `signup not found for id:${id}`);
+
           return this.getCurrentSignup(req);
         }
 
-        // TODO Ensure cached Signup is current by checking Campaign end date.
-        return signup;        
+        // TODO Validate cached Signup is current by checking Campaign end date.
+        return signup;
       });
   }
 
@@ -308,8 +308,9 @@ class CampaignBotController {
         if (user) {
           return user;
         }
+
         return this.getUser(id);
-      })
+      });
   }
 
   /**
@@ -318,7 +319,7 @@ class CampaignBotController {
    * @return {string}
    */
   loggerPrefix(req) {
-    return 'campaignBot.campaign:' + req.campaign_id + ' user:' + req.user_id;
+    return `campaignBot.campaign:${req.campaign_id} user:${req.user_id}`;
   }
 
   /**
@@ -330,7 +331,7 @@ class CampaignBotController {
     this.debug(req, 'postReportback');
 
     const submission = req.signup.draft_reportback_submission;
-    const postData = {
+    const data = {
       source: process.env.DS_API_POST_SOURCE,
       uid: req.user.phoenix_id,
       quantity: submission.quantity,
@@ -338,15 +339,13 @@ class CampaignBotController {
       file_url: submission.photo,
     };
     if (submission.why_participated) {
-      postData.why_participated = submission.why_participated;
+      data.why_participated = submission.why_participated;
     }
 
     return app.locals.clients.phoenix.Campaigns
-      .reportback(req.campaign_id, postData)
-      .then(reportbackId => {
-        return this.postReportbackSuccess(req, reportbackId);
-      })
-      .catch(err => {
+      .reportback(req.campaign_id, data)
+      .then(rbId => this.postReportbackSuccess(req, rbId))
+      .catch((err) => {
         submission.failed_at = Date.now();
         req.signup.save();
 
@@ -366,25 +365,24 @@ class CampaignBotController {
     const dateSubmitted = Date.now();
     const submission = req.signup.draft_reportback_submission;
     submission.submitted_at = dateSubmitted;
+    const currentSignup = req.signup;
 
     return submission
       .save()
       .then(() => {
-        req.signup.reportback = rbid;
-        req.signup.total_quantity_submitted = submission.quantity;
-        req.signup.updated_at = dateSubmitted;
-        req.signup.draft_reportback_submission = undefined;
-        req.signup.save();
+        currentSignup.reportback = rbid;
+        currentSignup.total_quantity_submitted = submission.quantity;
+        currentSignup.updated_at = dateSubmitted;
+        currentSignup.draft_reportback_submission = null;
+        currentSignup.save();
       })
-      .then(() => {
-        return this.renderResponseMessage(req, this.bot.msg_menu_completed);
-      });
+      .then(this.renderResponseMessage(req, this.bot.msg_menu_completed));
   }
 
   /**
    * Posts Signup to DS API and returns cached signup.
    * @param {object} req - Express request
-   * @return {object} - Returned Signup model
+   * @return {object} - Constructed Signup response object from new Signup id
    */
   postSignup(req) {
     this.debug(req, 'postSignup');
@@ -394,13 +392,11 @@ class CampaignBotController {
         source: process.env.DS_API_POST_SOURCE,
         uid: req.user.phoenix_id,
       })
-      .then(signupId => {
-        return {
-          _id: signupId,
-          campaign: req.campaign_id,
-          user: req.user_id,
-        };
-      });
+      .then((signupId) => ({
+        _id: signupId,
+        campaign: req.campaign_id,
+        user: req.user_id,
+      }));
   }
 
   /**
@@ -414,32 +410,28 @@ class CampaignBotController {
       return this.error(req, 'getMessage no msgTxt');
     }
 
-    msgTxt = msgTxt.replace(/<br>/gi, '\n');
-    msgTxt = msgTxt.replace(/{{title}}/gi, req.campaign.title);
-    msgTxt = msgTxt.replace(/{{rb_noun}}/gi, req.campaign.rb_noun);
-    msgTxt = msgTxt.replace(/{{rb_verb}}/gi, req.campaign.rb_verb);
+    let msg = msgTxt.replace(/<br>/gi, '\n');
+    msg = msg.replace(/{{title}}/gi, req.campaign.title);
+    msg = msg.replace(/{{rb_noun}}/gi, req.campaign.rb_noun);
+    msg = msg.replace(/{{rb_verb}}/gi, req.campaign.rb_verb);
 
     if (req.signup) {
-      let quantity = req.signup.total_quantity_submitted
+      let quantity = req.signup.total_quantity_submitted;
       if (req.signup.draft_reportback_submission) {
         quantity = req.signup.draft_reportback_submission.quantity;
       }
-      msgTxt = msgTxt.replace(/{{quantity}}/gi, quantity);
+      msg = msg.replace(/{{quantity}}/gi, quantity);
     }
 
     if (req.query.start && req.signup && req.draft_reportback_submission) {
-      // @todo New bot property for continue draft message
-      var continueMsg = 'Picking up where you left off on ' + req.campaign.title;
-      msgTxt = continueMsg + '...\n\n' + msgTxt;
+      // TODO: New bot property for continue draft message
+      const continueMsg = 'Picking up where you left off on';
+      msg = `${continueMsg} ${req.campaign.title}...\n\n${msg}`;
     }
 
-    if (process.env.NODE_ENV !== 'production') {
-      msgTxt = '@stg: ' + msgTxt;
-    }
-
-    return msgTxt;
+    return msg;
   }
 
-};
+}
 
 module.exports = CampaignBotController;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -365,16 +365,17 @@ class CampaignBotController {
     const dateSubmitted = Date.now();
     const submission = req.signup.draft_reportback_submission;
     submission.submitted_at = dateSubmitted;
-    const currentSignup = req.signup;
 
     return submission
       .save()
       .then(() => {
-        currentSignup.reportback = rbid;
-        currentSignup.total_quantity_submitted = submission.quantity;
-        currentSignup.updated_at = dateSubmitted;
-        currentSignup.draft_reportback_submission = null;
-        currentSignup.save();
+        /* eslint-disable no-param-reassign */
+        req.signup.reportback = rbid;
+        req.signup.total_quantity_submitted = submission.quantity;
+        req.signup.updated_at = dateSubmitted;
+        req.signup.draft_reportback_submission = null;
+        /* eslint-enable no-param-reassign */
+        req.signup.save();
       })
       .then(this.renderResponseMessage(req, 'menu_completed'));
   }

--- a/api/controllers/SlothBotController.js
+++ b/api/controllers/SlothBotController.js
@@ -1,31 +1,29 @@
-"use strict";
-
-var mobilecommons = rootRequire('lib/mobilecommons');
-var logger = rootRequire('lib/logger');
+'use strict';
 
 /**
- * SlothBotController
- * @constructor
+ * Imports.
  */
-function SlothBotController() {};
+const logger = rootRequire('lib/logger');
 
 /**
- * Welcome to season 2!
- * @param {object} request - Express request
- * @param {object} response - Express response
+ * SlothBotController.
  */
-SlothBotController.prototype.chatbot = function(request, response) {
-  var phone = request.body.phone;
-  var incomingMsg = request.body.args;
-  logger.debug("user:" + phone + " sent @slothbot a message:" + incomingMsg);
-  response.send();
+class SlothBotController {
 
-  var reply = '@slothbot: Thank you so much for talking to me. ';
-  reply += 'I just sit on an office couch all day. ';
-  reply += 'You just told me:\n\n' + incomingMsg;
+  /**
+   * @param {object} req - Express request
+   * @return {string}
+   */
+  renderResponseMessage(req) {
+    const profile = req.body;
+    logger.debug(`${profile.phone} sent slothbot:${profile.args}`);
 
-  // @todo Move hardcoded value into environment variable.
-  mobilecommons.chatbot(request.body, 210045, reply);
+    let msgTxt = '@slothbot: Thank you so much for talking to me. ';
+    msgTxt += 'I just sit on an office couch all day. ';
+    msgTxt += `You just told me:\n\n${profile.args}`;
+
+    return msgTxt;
+  }
 }
 
 module.exports = SlothBotController;

--- a/api/models/ChatbotMobileCommonsCampaign.js
+++ b/api/models/ChatbotMobileCommonsCampaign.js
@@ -1,6 +1,12 @@
-var mongoose = require('mongoose');
+'use strict';
 
-var schema = new mongoose.Schema({
+/**
+ * Models a Mobile Commons Campaign used by Gambit chatbot.
+ */
+const mongoose = require('mongoose');
+
+const schema = new mongoose.Schema({
+
   // Mobile Commons Campaign ID:
   // e.g. https://secure.mcommons.com/campaigns/[id]
   _id: Number,
@@ -8,10 +14,11 @@ var schema = new mongoose.Schema({
   __comments: String,
   oip_chat: Number,
   oip_success: Number,
-  oip_error: Number
+  oip_error: Number,
+
 });
 
-module.exports = function(connection) {
-  var name = 'chatbot_mobilecommons_campaigns';
+module.exports = function (connection) {
+  const name = 'chatbot_mobilecommons_campaigns';
   return connection.model(app.ConfigName.CHATBOT_MOBILECOMMONS_CAMPAIGNS, schema, name);
 };

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,30 +1,24 @@
+'use strict';
+
 /**
  * Models a DS User.
  */
-var mongoose = require('mongoose');
-var Mixed = mongoose.Schema.Types.Mixed;
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
 
-  _id: {type: String, index: true},
-
-  mobile: {type: String, index: true},
-
+  _id: { type: String, index: true },
+  // TODO: Not sure we need this index
+  mobile: { type: String, index: true },
   phoenix_id: Number,
-
   email: String,
-
   role: String,
-
   first_name: String,
-
-  supports_mms: {type: Boolean, default: false},
-
   // Hash table to store current signups: e.g. campaigns[campaignId] = signupId;
-  campaigns: {type: Mixed, default: {}}
+  campaigns: { type: mongoose.Schema.Types.Mixed, default: {} },
 
-})
+});
 
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model('users', schema);
 };

--- a/api/models/campaign/Campaign.js
+++ b/api/models/campaign/Campaign.js
@@ -1,28 +1,23 @@
+'use strict';
+
 /**
  * Models a DS Campaign.
  */
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
 
-  _id: {type: Number, index: true},
-
+  _id: { type: Number, index: true },
   title: String,
-
   rb_noun: String,
-
   rb_verb: String,
 
-  // We're using Mobile Commons campaigns like Phoenix Campaign Runs.
-  // We create a new Mobile Commons campaign when the DS Campaign's 
-  // Signup and Quantity totals need start at 0 again for this year/month's run.
+  // TODO: Remove -- we'll use one Mobile Commons Campaign to run all DS Campaigns
   current_mobilecommons_campaign: Number,
+  staging_mobilecommons_campaign: Number,
 
-  // Internal Mobile Commons campaign to use for Gambit staging / development.
-  staging_mobilecommons_campaign: Number
+});
 
-})
-
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model('campaigns', schema);
 };

--- a/api/models/campaign/CampaignBot.js
+++ b/api/models/campaign/CampaignBot.js
@@ -1,11 +1,14 @@
+'use strict';
+
 /**
- * Model for Gambit Jr. API campaignbot. 
+ * Models a Gambit Jr. CampaignBot.
  * Each document contains content to use for each message sent in
  * a DS Campaign conversation.
  */
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
+
   // Corresponds to the campaignbot ID in Gambit Jr. API.
   _id: Number,
   msg_menu_signedup: String,
@@ -17,9 +20,10 @@ var schema = new mongoose.Schema({
   msg_no_photo_sent: String,
   msg_ask_caption: String,
   msg_ask_why_participated: String,
-  msg_menu_completed: String
+  msg_menu_completed: String,
+
 });
 
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model(app.ConfigName.CAMPAIGNBOTS, schema, 'campaignbots');
 };

--- a/api/models/campaign/ReportbackSubmission.js
+++ b/api/models/campaign/ReportbackSubmission.js
@@ -1,30 +1,24 @@
+'use strict';
+
 /**
- * Models each upsert submission posted to DS Reportback API.
+ * Models a upsert Reportback Submission posted to DS Reportback API.
  */
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
 
-  user: {type: String, index: true},
-
-  campaign: {type: Number, index: true},
-
-  created_at: {type: Date, default: Date.now},
-
+  user: { type: String, index: true },
+  campaign: { type: Number, index: true },
+  created_at: { type: Date, default: Date.now() },
   caption: String,
-
   photo: String,
-
   quantity: Number,
-
   why_participated: String,
-
   submitted_at: Date,
+  failed_at: Date,
 
-  failed_at: Date
+});
 
-})
-
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model('reportback_submissions', schema);
 };

--- a/api/models/campaign/Signup.js
+++ b/api/models/campaign/Signup.js
@@ -1,42 +1,31 @@
+'use strict';
+
 /**
  * Models a DS Signup.
  */
-
- /**
-  * Imports.
-  */
 const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
 
-  _id: {type: Number, index: true},
-
-  user: {type: String, index: true},
-
-  campaign: {type: Number, index: true},
-
-  created_at: {type: Date, default: Date.now},
-
-  // If user is in the middle of a Reportback Submission, we store its ID 
-  // for easy lookup.
+  _id: { type: Number, index: true },
+  user: { type: String, index: true },
+  campaign: { type: Number, index: true },
+  created_at: Date,
   draft_reportback_submission: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'reportback_submissions'
+    ref: 'reportback_submissions',
   },
-
   reportback: Number,
-
   // Last quantity submitted by the user.
   // We'll want to update this number from DS API once we're querying for
   // any existing or updates to Reportbacks for this Signup.
   total_quantity_submitted: Number,
-
   // Corresponds to the submitted_at of User's most recent ReportbackSubmission.
   // Set this value as last import date if we start querying for updates.
-  updated_at: Date
+  updated_at: Date,
 
-})
+});
 
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model('signups', schema);
 };

--- a/api/models/donation/DonorsChooseBot.js
+++ b/api/models/donation/DonorsChooseBot.js
@@ -1,12 +1,15 @@
+'use strict';
+
 /**
- * Model for Gambit Jr. API DonorsChooseBot. 
+ * Model for a Gambit Jr. DonorsChooseBot.
  * Each document contains copy to use for each message sent in DonorsChooseBot
  * Chatbot conversations.
  */
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
-  // Corresponds to the donorschoose_bot ID in Gambit Jr. API.
+const schema = new mongoose.Schema({
+
+  // Corresponds to the DonorsChooseBot ID in Gambit Jr. API.
   _id: Number,
   // Last refresh from Gambit Jr. API.
   refreshed_at: Date,
@@ -21,9 +24,10 @@ var schema = new mongoose.Schema({
   msg_project_link: String,
   msg_max_donations_reached: String,
   msg_search_start: String,
-  msg_search_no_results: String
+  msg_search_no_results: String,
+
 });
 
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model(app.ConfigName.DONORSCHOOSEBOTS, schema, 'donorschoosebots');
 };

--- a/api/models/donation/DonorsChooseDonation.js
+++ b/api/models/donation/DonorsChooseDonation.js
@@ -1,23 +1,24 @@
+'use strict';
+
 /**
- * Models successful DonorsChoose donation transactions. 
+ * Models a successful DonorsChoose donation transaction.
  */
-var mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
-var schema = new mongoose.Schema({
+const schema = new mongoose.Schema({
 
-  created_at: {type: Date, default: Date.now},
+  created_at: { type: Date, default: Date.now },
 
-  // Member profile information:
-  mobile: {type: String, index: true},
+  mobilecommons_campaign_id: Number,
+  donorschoosebot_id: Number,
+
+  // Member profile our donation is on behalf of.
+  mobile: { type: String, index: true },
   profile_email: String,
   profile_first_name: String,
   profile_postal_code: String,
 
-  // Keep config info for record-keeping:
-  mobilecommons_campaign_id: Number,
-  donorschoose_bot_id: Number,
-
-  // DonorsChoose information:
+  // DonorsChoose donation details:
   donation_id: Number,
   donation_amount: Number,
   proposal_id: Number,
@@ -25,10 +26,10 @@ var schema = new mongoose.Schema({
   proposal_remaining_amount: Number,
   school_name: String,
   school_city: String,
-  school_state: String
+  school_state: String,
 
-})
+});
 
-module.exports = function(connection) {
+module.exports = function (connection) {
   return connection.model('donorschoose_donation', schema);
 };

--- a/api/router.js
+++ b/api/router.js
@@ -132,14 +132,10 @@ function campaignBotRouter(req, res) {
       }
 
       if (signup.total_quantity_submitted) {
-        msgTxt = controller.bot.msg_menu_completed;
-
-        return controller.renderResponseMessage(req, msgTxt);
+        return controller.renderResponseMessage(req, 'menu_completed');
       }
 
-      msgTxt = controller.bot.msg_menu_signedup;
-
-      return controller.renderResponseMessage(req, msgTxt);
+      return controller.renderResponseMessage(req, 'menu_signedup');
     })
     .then(msg => {
       controller.debug(req, `sendMessage:${msg}`);

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -5,32 +5,10 @@ const router = express.Router(); // eslint-disable-line new-cap
 const logger = rootRequire('lib/logger');
 const mobilecommons = rootRequire('lib/mobilecommons');
 
-app.use('/', router);
-
-router.get('/', (req, res) => res.send('hi'));
-
 /**
- * Authentication.
+ * Handle chatbot conversations.
  */
-router.use((req, res, next) => {
-  const apiKey = process.env.GAMBIT_API_KEY;
-  if (req.method === 'POST' && req.headers['x-gambit-api-key'] !== apiKey) {
-    logger.warn('router invalid x-gambit-api-key:', req.url);
-    return res.sendStatus(403);
-  }
-  return next();
-});
-
-/**
- * Legacy routes.
- */
-const campaignRouter = require('./legacy/ds-routing');
-const reportbackRouter = require('./legacy/reportback');
-
-router.use('/ds-routing', campaignRouter);
-router.use('/reportback', reportbackRouter);
-
-router.post('/v1/chatbot', (req, res) => {
+router.post('/', (req, res) => {
   // TODO: Handle when Northstar ID doesn't exist.
   req.user_id = req.body.profile_northstar_id; // eslint-disable-line no-param-reassign
   req.user_mobile = req.body.phone; // eslint-disable-line no-param-reassign
@@ -47,30 +25,14 @@ router.post('/v1/chatbot', (req, res) => {
 
     return res.send({ message: msgTxt });
   }
+
   if (botType === 'donorschoose' || botType === 'donorschoosebot') {
-    const DonorsChooseBot = require('./controllers/DonorsChooseBotController');
+    const DonorsChooseBot = rootRequire('api/controllers/DonorsChooseBotController');
     const donorsChooseBot = new DonorsChooseBot();
 
     return donorsChooseBot.chatbot(req, res);
   }
 
-  return campaignBotRouter(req, res);
-});
-
-
-/**
- * Sync chatbot content from Gambit Jr. API.
- */
-router.post('/v1/chatbot/sync', (req, res) => {
-  const gambitJunior = rootRequire('lib/gambit-junior');
-
-  gambitJunior.syncBotConfigs(req, res, req.query.bot_type);
-});
-
-/**
- * Routing for the CampaignBot.
- */
-function campaignBotRouter(req, res) {
   req.campaign_id = req.query.campaign; // eslint-disable-line no-param-reassign
   const controller = app.locals.campaignBot;
   controller.debug(req, `msg:${req.incoming_message} img:${req.incoming_image_url}`);
@@ -142,4 +104,18 @@ function campaignBotRouter(req, res) {
       controller.error(req, res, err);
       return res.sendStatus(500);
     });
-}
+});
+
+/**
+ * Sync chatbot configs
+ */
+router.post('/sync', (req, res) => {
+  const gambitJunior = rootRequire('lib/gambit-junior');
+
+  // TODO: Handle response here, not in gambitJunior.
+  gambitJunior.syncBotConfigs(req, res, req.query.bot_type);
+});
+
+
+module.exports = router;
+

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -10,10 +10,12 @@ const mobilecommons = rootRequire('lib/mobilecommons');
  */
 router.post('/', (req, res) => {
   // TODO: Handle when Northstar ID doesn't exist.
-  req.user_id = req.body.profile_northstar_id; // eslint-disable-line no-param-reassign
-  req.user_mobile = req.body.phone; // eslint-disable-line no-param-reassign
-  req.incoming_message = req.body.args; // eslint-disable-line no-param-reassign
-  req.incoming_image_url = req.body.mms_image_url; // eslint-disable-line no-param-reassign
+  /* eslint-disable no-param-reassign */
+  req.user_id = req.body.profile_northstar_id;
+  req.user_mobile = req.body.phone;
+  req.incoming_message = req.body.args;
+  req.incoming_image_url = req.body.mms_image_url;
+  /* eslint-enable no-param-reassign */
 
   const botType = req.query.bot_type;
 

--- a/config/router.js
+++ b/config/router.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router(); // eslint-disable-line new-cap
+const logger = rootRequire('lib/logger');
+
+app.use('/', router);
+
+router.get('/', (req, res) => res.send('hi'));
+
+/**
+ * Authentication.
+ */
+router.use((req, res, next) => {
+  const apiKey = process.env.GAMBIT_API_KEY;
+  if (req.method === 'POST' && req.headers['x-gambit-api-key'] !== apiKey) {
+    logger.warn('router invalid x-gambit-api-key:', req.url);
+    return res.sendStatus(403);
+  }
+  return next();
+});
+
+/**
+ * Chatbot routes.
+ */
+const chatbotRouter = rootRequire('config/router-chatbot');
+router.use('/v1/chatbot', chatbotRouter);
+
+/**
+ * Legacy routes.
+ */
+const campaignRouter = rootRequire('api/legacy/ds-routing');
+const reportbackRouter = rootRequire('api/legacy/reportback');
+
+router.use('/ds-routing', campaignRouter);
+router.use('/reportback', reportbackRouter);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node server",
-    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js"
+    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js api/router.js"
   },
   "eslintConfig": {
     "globals": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node server",
-    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js config/router.js config/router-chatbot.js"
+    "lint": "eslint --ext=.js api/models api/controllers/CampaignBotController.js config/router.js config/router-chatbot.js"
   },
   "eslintConfig": {
     "globals": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node server",
-    "lint": "eslint --ext=.js api/controllers"
+    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js"
   },
   "eslintConfig": {
     "globals": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,20 @@
     "type": "git",
     "url": "git+https://github.com/DoSomething/gambit.git"
   },
+  "scripts": {
+    "test": "npm run lint",
+    "start": "node server",
+    "lint": "eslint --ext=.js api/controllers"
+  },
+  "eslintConfig": {
+    "globals": {
+      "app": true,
+      "rootRequire": true
+    }
+  },
+  "engines": {
+    "node": ">=4.4.x"
+  },
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
@@ -33,11 +47,9 @@
     "winston": "0.8.x",
     "winston-mongodb": "0.5.x"
   },
-  "scripts": {
-    "test": "make test",
-    "start": "node server"
-  },
-  "engines": {
-    "node": ">=4.4.x"
+  "devDependencies": {
+    "@dosomething/eslint-config": "^1.1.1",
+    "eslint": "^2.10.2",
+    "eslint-plugin-react": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node server",
-    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js api/router.js"
+    "lint": "eslint --ext=.js api/controllers/CampaignBotController.js config/router.js config/router-chatbot.js"
   },
   "eslintConfig": {
     "globals": {

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ app = express();
 const appConfig = require('./config')(); 
 const smsConfigsLoader = require('./config/smsConfigsLoader');
 
-const router = require('./api/router');
+const router = rootRequire('config/router');
 
 const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
 const SlothBotController = rootRequire('api/controllers/SlothBotController');

--- a/server.js
+++ b/server.js
@@ -33,12 +33,17 @@ const smsConfigsLoader = require('./config/smsConfigsLoader');
 const router = require('./api/router');
 
 const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
+const SlothBotController = rootRequire('api/controllers/SlothBotController');
 
 // Retrieves all SMS config files before starting server.
 smsConfigsLoader(() => {
   const port = (process.env.PORT || 5000);
-  // @todo We'll need to loop through all campaignBots and store as array.
-  app.locals.campaignBotController = new CampaignBotController(41);
+
+  // TODO Create our controllers (which read from configs in smsConfigsLoader)
+  // We'll need to loop through all campaignBots and store as array.
+  app.locals.campaignBot = new CampaignBotController(41);
+  app.locals.slothBot = new SlothBotController();
+
   app.listen(port, () => {
     logger.info(`Gambit is listening, port:${port} env:${process.env.NODE_ENV}.`);
   });


### PR DESCRIPTION
#### What's this PR do?
- Adds a `eslintrc` and our [DS ESLint config](https://github.com/DoSomething/eslint-config)
- Adds `npm run lint`as a test script, only linting for CampaignBot work for now to keep this PR almost readable -- but more cleanup pull requests are on the horizon
- Cleanup `CampaignBotController`, `SlothBotController`, all `/api/models/`
- Move `api/router.js` into `config/router.js`, separates `/v1/chatbot` routing into new `config/router-chatbot.js`
- Refactors the `CampaignBotontroller.renderResponseMessage` 2nd parameter function to expect the bot message type instead of the actual message text to render -- to DRY calls to `this.bot` properties (the `CampaignBotController.bot` contains all possible response messages to send back)
#### How should this be reviewed?

👀 , `npm test`
#### Any background context you want to provide?
- I started on linting the DonorsChooseBotController (https://github.com/DoSomething/gambit/commit/f161315b3ea9e6f195a9bec494254b08319b1588) -- but it's in pretty desperate need of a callback hell makeover a la #632. Lower priority at the moment. 
- Considering just creating a root `legacy` directory to move everything we plan to 🔥 in one directory.
- Next up, lint the `config` directory and get wercker back into the scene
#### Relevant tickets
#635
#### Checklist
- [x] Documentation added for new features: https://github.com/DoSomething/gambit/wiki/Development#testing
- [x] Tested on staging.
