### PR TITLE
Adds User.current_campaign property, CampaignBot MobileCommons OIP config variable

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -36,7 +36,7 @@ class CampaignBotController {
   collectReportbackProperty(req, property, ask) {
     this.debug(req, `collectReportbackProperty:${property}`);
 
-    if (req.query.start || ask) {
+    if (req.query.campaign || ask) {
       return this.renderResponseMessage(req, `ask_${property}`);
     }
 
@@ -85,7 +85,7 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = req.query.start || false;
+    const ask = req.query.campaign || false;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);
@@ -435,7 +435,7 @@ class CampaignBotController {
       msg = msg.replace(/{{quantity}}/gi, quantity);
     }
 
-    if (req.query.start && req.signup && req.signup.draft_reportback_submission) {
+    if (req.query.campaign && req.signup && req.signup.draft_reportback_submission) {
       // TODO: New bot property for continue draft message
       const continueMsg = 'Picking up where you left off on';
       msg = `${continueMsg} ${req.campaign.title}...\n\n${msg}`;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -444,6 +444,19 @@ class CampaignBotController {
     return msg;
   }
 
+  /**
+   * Updates the given User model's current_campaign property to given campaignId.
+   */
+  setCurrentCampaign(user, campaignId) {
+    if (campaignId === user.current_campaign) {
+      return true;
+    }
+
+    return app.locals.db.users
+      .findByIdAndUpdate(user._id, { current_campaign: campaignId })
+      .exec();
+  }
+
 }
 
 module.exports = CampaignBotController;

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -16,6 +16,8 @@ const schema = new mongoose.Schema({
   first_name: String,
   // Hash table to store current signups: e.g. campaigns[campaignId] = signupId;
   campaigns: { type: mongoose.Schema.Types.Mixed, default: {} },
+  // Campaign the user is currently participating in via chatbot.
+  current_campaign: Number,
 
 });
 

--- a/api/models/campaign/Campaign.js
+++ b/api/models/campaign/Campaign.js
@@ -12,10 +12,6 @@ const schema = new mongoose.Schema({
   rb_noun: String,
   rb_verb: String,
 
-  // TODO: Remove -- we'll use one Mobile Commons Campaign to run all DS Campaigns
-  current_mobilecommons_campaign: Number,
-  staging_mobilecommons_campaign: Number,
-
 });
 
 module.exports = function (connection) {

--- a/config/locals.js
+++ b/config/locals.js
@@ -125,10 +125,8 @@ module.exports.load = function () {
 
   return Promise.all(locals).then(() => {
     const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
-    // TODO: We'll need to loop through all campaignBots and store as app.locals.campignBots map.
-    // For now we only have one default CampaignBot (id 41) to use for all DS Campaigns.
-    // TODO: Add config variable to avoid hardcoding default CampaignBot.
-    const campaignBot = app.locals.configs.campaignBots[41];
+    // TODO: Support multiple campaignBots, to allow campaigns to override default message copy.
+    const campaignBot = app.locals.configs.campaignBots[process.env.CAMPAIGNBOT_ID];
     app.locals.campaignBot = new CampaignBotController(campaignBot);
 
     const DonorsChooseBotController = rootRequire('api/controllers/DonorsChooseBotController');

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -40,15 +40,6 @@ router.post('/', (req, res) => {
   const campaign = app.locals.configs.campaigns[req.campaign_id];
   req.campaign = campaign; // eslint-disable-line no-param-reassign
 
-  // TODO: Mobile Commons Campaign will be shared by all DS Campaigns
-  // @see https://github.com/DoSomething/gambit/issues/633
-  let mocoId = req.campaign.staging_mobilecommons_campaign;
-  if (process.env.NODE_ENV === 'production') {
-    mocoId = req.campaign.current_mobilecommons_campaign;
-  }
-  const mobilecommonsCampaign = app.locals.configs.chatbotMobileCommonsCampaigns[mocoId];
-  const mobilecommonsOptinPath = mobilecommonsCampaign.oip_chat;
-
   return controller
     .loadUser(req.user_id)
     .then(user => {
@@ -91,7 +82,7 @@ router.post('/', (req, res) => {
     })
     .then(msg => {
       controller.debug(req, `sendMessage:${msg}`);
-      mobilecommons.chatbot(req.body, mobilecommonsOptinPath, msg);
+      mobilecommons.chatbot(req.body, process.env.CAMPAIGNBOT_MOBILECOMMONS_OIP, msg);
 
       return res.send({ message: msg });
     })

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -17,6 +17,8 @@ router.post('/', (req, res) => {
   req.incoming_image_url = req.body.mms_image_url;
   /* eslint-enable no-param-reassign */
 
+  logger.debug(`user:${req.user_id} msg:${req.incoming_message} img:${req.incoming_image_url}`);
+
   const botType = req.query.bot_type;
 
   if (botType === 'slothbot') {
@@ -33,7 +35,18 @@ router.post('/', (req, res) => {
   }
 
   const controller = app.locals.campaignBot;
-  controller.debug(req, `msg:${req.incoming_message} img:${req.incoming_image_url}`);
+  if (!controller.bot) {
+    logger.error('CampaignBotController.bot undefined');
+
+    return res.sendStatus(500);
+  }
+
+  const mobilecommonsOip = process.env.CAMPAIGNBOT_MOBILECOMMONS_OIP;
+  if (!mobilecommonsOip) {
+    logger.error('CAMPAIGNBOT_MOBILECOMMONS_OIP undefined');
+
+    return res.sendStatus(500);
+  }
 
   return controller
     .loadUser(req.user_id)
@@ -90,7 +103,7 @@ router.post('/', (req, res) => {
       controller.debug(req, `sendMessage:${msg}`);
       controller.setCurrentCampaign(req.user, req.campaign_id);
 
-      mobilecommons.chatbot(req.body, process.env.CAMPAIGNBOT_MOBILECOMMONS_OIP, msg);
+      mobilecommons.chatbot(req.body, mobilecommonsOip, msg);
 
       return res.send({ message: msg });
     })


### PR DESCRIPTION
#### What's this PR do?
- Changes all CampaignBot Mobile Commons `profile_update` requests to post to a single Opt-in Path, defined by `CAMPAIGNBOT_MOBILECOMMONS_OIP` config variable (set to 214465 for staging)
  - Removes deprecated `current_mobilecommons_campaign` and `staging_mobilecommons_campaign` properties from our Campaign `config` model
- Adds a `User.current_campaign` property to store the DS Campaign the User is currently participating in:
  - If a `campaign=123` is passed in the query string, use it to load the DS Campaign 123 and saving User activity to. Upon creating or loading signup, set the user's `current_campaign`property  to 123.
  - If a `campaign` is not passed as a query parameter, load the DS Campaign saved to our `user.current_campaign` property
- Sets a `CAMPAIGNBOT_ID` config variable to loading our default CampaignBot message copy (was previously hardcoded to id [41](http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/campaignbots/41))
- Deprecates the `start=true` parameter in favor of checking for the `campaign` parameter -- only time we should pass a `campaign` parameter is to change current chatbot conversation to signup/continue confirmation for the given campaign.
#### How should this be reviewed?

Test on staging. I made following changes in Mobile Commons to implement:
- Our OIP 214465 triggers our "Staging CampaignBot" mData which posts to `/v1/chatbot` -- no `campaign` is passed into the query string, so all responses to this OIP will load the saved User's `current_campaign`
- Our Bumble Bands keyword / mData posts to `/v1/chatbot?campaign=2299`
- Our Two Books keyword / mData posts to `/v1/chatbot?campaign=2070`
#### Any background context you want to provide?

We'll want to cache a DS Campaign's `status` property soon to determine whether the Campaign should be available to participate in via SMS.
#### Relevant tickets

Fixes #633
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
