### PR TITLE
AgentView support

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -254,7 +254,7 @@ class CampaignBotController {
 
     const result = this.parseCommand(req) === configValue.toUpperCase();
 
-    if (type === 'clear_cache') {
+    if (result && type === 'clear_cache') {
       if (!this.isStaff(req.user)) {
         logger.warn(`${this.loggerPrefix(req)} unauthorized command clear_cache`);
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -247,7 +247,7 @@ class CampaignBotController {
     const configName = `GAMBIT_CMD_${type.toUpperCase()}`;
     const configValue = process.env[configName];
     if (!configValue) {
-      logger.error(`${this.loggerPrefix(req)} process.env.${configName} is undefined`);
+      logger.warn(`${this.loggerPrefix(req)} process.env.${configName} is undefined`);
 
       return false;
     }

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -438,13 +438,13 @@ class CampaignBotController {
 
     msg = msg.replace(/{{br}}/gi, '\n');
     msg = msg.replace(/{{title}}/gi, campaign.title);
-    msg = msg.replace(/{{tagline}}/gi, campaign.tagline);
+    msg = msg.replace(/{{tagline}}/i, campaign.tagline);
     msg = msg.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
     msg = msg.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
-    msg = msg.replace(/{{rb_confirmed}}/gi, campaign.reportbackInfo.confirmationMessage);
-    msg = msg.replace(/{{cmd_reportback}}/gi, process.env.GAMBIT_CMD_REPORTBACK);
-    msg = msg.replace(/{{cmd_member_support}}/gi, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
-    msg = msg.replace(/{{keyword}}/gi, campaign.keywords);
+    msg = msg.replace(/{{rb_confirmed}}/i, campaign.reportbackInfo.confirmationMessage);
+    msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
+    msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+    msg = msg.replace(/{{keyword}}/i, process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT);
 
     if (req.signup) {
       let quantity = req.signup.total_quantity_submitted;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -31,7 +31,7 @@ class CampaignBotController {
   collectReportbackProperty(req, property, ask) {
     this.debug(req, `collectReportbackProperty:${property}`);
 
-    if (req.query.campaign || ask) {
+    if (req.query.campaign || ask || this.isKeywordCampaignBot(req)) {
       return this.renderResponseMessage(req, `ask_${property}`);
     }
 
@@ -267,6 +267,18 @@ class CampaignBotController {
   }
 
   /**
+   * Returns whether incoming request is the CampaignBot Mobile Commons keyword.
+   * @param {object} req
+   * @return {bool}
+   */
+  isKeywordCampaignBot(req) {
+    const keyword = process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT;
+    const isKeyword = this.parseCommand(req) == keyword.toUpperCase();
+
+    return isKeyword;
+  }
+
+  /**
    * Loads Signup model if exists for given id, else get/create from API.
    * @param {object} req - Express request
    * @param {number} id - DS Signup ID
@@ -320,7 +332,7 @@ class CampaignBotController {
 
   /**
    * Parse incoming request as Gambit command.
-  */
+   */
   parseCommand(req) {
     return helpers.getFirstWordUppercase(req.incoming_message);
   }
@@ -444,7 +456,8 @@ class CampaignBotController {
       msg = msg.replace(/{{quantity}}/gi, quantity);
     }
 
-    if (req.query.campaign && req.signup && req.signup.draft_reportback_submission) {
+    const revisiting = req.query.campaign && req.signup && req.signup.draft_reportback_submission;
+    if (revisiting || this.isKeywordCampaignBot(req)) {
       // TODO: New bot property for continue draft message
       const continueMsg = 'Picking up where you left off on';
       msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -426,20 +426,15 @@ class CampaignBotController {
       return this.error(req, 'bot msgType not found');
     }
 
-    const mobilecommonsKeyword = process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT;
-
     msg = msg.replace(/{{br}}/gi, '\n');
     msg = msg.replace(/{{title}}/gi, campaign.title);
     msg = msg.replace(/{{tagline}}/gi, campaign.tagline);
     msg = msg.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
     msg = msg.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
     msg = msg.replace(/{{rb_confirmed}}/gi, campaign.reportbackInfo.confirmationMessage);
-
-    if (!mobilecommonsKeyword) {
-      logger.error('mobilecommonsKeyword undefined');
-    } else {
-      msg = msg.replace(/{{keyword_continue}}/gi, mobilecommonsKeyword);
-    }
+    msg = msg.replace(/{{cmd_reportback}}/gi, process.env.GAMBIT_CMD_REPORTBACK);
+    msg = msg.replace(/{{cmd_member_support}}/gi, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+    msg = msg.replace(/{{keyword_continue}}/gi, process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT);
 
     if (req.signup) {
       let quantity = req.signup.total_quantity_submitted;

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -272,10 +272,13 @@ class CampaignBotController {
    * @return {bool}
    */
   isKeywordCampaignBot(req) {
-    const keyword = process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT;
-    const isKeyword = this.parseCommand(req) == keyword.toUpperCase();
+    if (req.body.keyword) {
+      const keyword = process.env.MOBILECOMMONS_KEYWORD_CAMPAIGNBOT;
+      const isKeyword = req.body.keyword.toUpperCase() === keyword.toUpperCase();
+      return isKeyword;
+    }
 
-    return isKeyword;
+    return false;
   }
 
   /**

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -454,8 +454,8 @@ class CampaignBotController {
       msg = msg.replace(/{{quantity}}/gi, quantity);
     }
 
-    const continuing = req.body.keyword && req.signup && req.signup.draft_reportback_submission;
-    if (continuing) {
+    const revisiting = req.body.keyword && req.signup && req.signup.draft_reportback_submission;
+    if (revisiting) {
       // TODO: New bot property for continue draft message
       const continueMsg = 'Picking up where you left off on';
       msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;

--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -3,7 +3,7 @@
 /**
  * Submits a donation to DonorsChoose.org on behalf of a Mobile Commons profile.
  * Currently only supports running one DonorsChoose Donation Campaign at a time,
- * set by the DONORSCHOOSEBOT_MOBILECOMMONS_OIP environment variables.
+ * set by the MOBILECOMMONS_OIP_DONORSCHOOSEBOT environment variables.
  */
 var donorsChooseApiKey = process.env.DONORSCHOOSE_API_KEY;
 var donorsChooseApiPassword = process.env.DONORSCHOOSE_API_PASSWORD;
@@ -27,10 +27,10 @@ var donorschoose = rootRequire('lib/donorschoose');
 function DonorsChooseBotController(donorsChooseBot) {
   this.bot = donorsChooseBot;
   // Mobile Commons OIP posts back user's response to our chatbot?bot_type=donorschoosebot.
-  this.oipChat = process.env.DONORSCHOOSEBOT_MOBILECOMMONS_OIP;
+  this.oipChat = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT;
   // Mobile Commons OIPs that no longer posts user responses back to chatbot.
-  this.oipSuccess = process.env.DONORSCHOOSEBOT_MOBILECOMMONS_OIP_SUCCESS;
-  this.oipError = process.env.DONORSCHOOSEBOT_MOBILECOMMONS_OIP_ERROR;
+  this.oipSuccess = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT_END;
+  this.oipError = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ERROR;
 };
 
 /**

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -39,9 +39,13 @@ router.post('/', (req, res) => {
 
   let configured = true;
   // Check for required config variables.
-  const settings = ['MOBILECOMMONS_OIP_CAMPAIGNBOT', 'MOBILECOMMONS_OIP_AGENTVIEW'];
-  settings.push('MOBILECOMMONS_KEYWORD_CAMPAIGNBOT');
-  settings.concat(['GAMBIT_CMD_MEMBER_SUPPORT', 'GAMBIT_CMD_REPORTBACK']);
+  const settings = [
+    'GAMBIT_CMD_MEMBER_SUPPORT',
+    'GAMBIT_CMD_REPORTBACK',
+    'MOBILECOMMONS_KEYWORD_CAMPAIGNBOT',
+    'MOBILECOMMONS_OIP_AGENTVIEW',
+    'MOBILECOMMONS_OIP_CAMPAIGNBOT',
+  ];
   settings.forEach((configVar) => {
     if (!process.env[configVar]) {
       logger.error(`undefined process.env.${configVar}`);

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -34,9 +34,9 @@ router.post('/', (req, res) => {
     return app.locals.controllers.donorsChooseBot.chatbot(req, res);
   }
 
-  const mobilecommonsOip = process.env.CAMPAIGNBOT_MOBILECOMMONS_OIP;
+  const mobilecommonsOip = process.env.MOBILECOMMONS_OIP_CAMPAIGNBOT;
   if (!mobilecommonsOip) {
-    logger.error('CAMPAIGNBOT_MOBILECOMMONS_OIP undefined');
+    logger.error('MOBILECOMMONS_OIP_CAMPAIGNBOT undefined');
 
     return res.sendStatus(500);
   }

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -1,9 +1,13 @@
 'use strict';
 
+/**
+ * Imports.
+ */
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
 const logger = rootRequire('lib/logger');
 const mobilecommons = rootRequire('lib/mobilecommons');
+const helpers = rootRequire('lib/helpers');
 
 /**
  * Handle chatbot conversations.
@@ -18,6 +22,16 @@ router.post('/', (req, res) => {
   /* eslint-enable no-param-reassign */
 
   logger.debug(`user:${req.user_id} msg:${req.incoming_message} img:${req.incoming_image_url}`);
+
+
+  const commandQuestion = process.env.GAMBIT_CMD_QUESTION || 'QT';
+  if (helpers.getFirstWordUppercase(req.incoming_message) === commandQuestion) {
+    const oip = process.env.MOBILECOMMONS_OIP_AGENTVIEW;
+    const msg = process.env.MOBILECOMMONS_OIP_AGENTVIEW_MESSAGE;
+    mobilecommons.chatbot(req.body, oip, msg);
+
+    return res.send({ message: 'Opted into AgentView' });
+  }
 
   const botType = req.query.bot_type;
 

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -93,7 +93,7 @@ router.post('/', (req, res) => {
       req.campaign_id = campaignId; // eslint-disable-line no-param-reassign
       req.campaign = campaign; // eslint-disable-line no-param-reassign
 
-      if (controller.isCommandClearCache(req)) {
+      if (controller.isCommand(req, 'clear_cache')) {
         req.user.campaigns = {}; // eslint-disable-line no-param-reassign
         logger.info(`${controller.loggerPrefix(req)} cleared user.campaigns`);
 
@@ -117,7 +117,7 @@ router.post('/', (req, res) => {
         logger.error('signup undefined');
       }
 
-      if (controller.isCommandMemberSupport(req)) {
+      if (controller.isCommand(req, 'member_support')) {
         return controller.renderResponseMessage(req, 'member_support');
       }
 
@@ -125,7 +125,7 @@ router.post('/', (req, res) => {
         return controller.continueReportbackSubmission(req);
       }
 
-      if (controller.isCommandReportback(req)) {
+      if (controller.isCommand(req, 'reportback')) {
         return controller.createReportbackSubmission(req);
       }
 
@@ -139,7 +139,7 @@ router.post('/', (req, res) => {
       controller.debug(req, `sendMessage:${msg}`);
       controller.setCurrentCampaign(req.user, req.campaign_id);
 
-      if (controller.isCommandMemberSupport(req)) {
+      if (controller.isCommand(req, 'member_support')) {
         mobilecommonsOip = process.env.MOBILECOMMONS_OIP_AGENTVIEW || 217171;
       }
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,8 +9,6 @@ This is __Gambit__, a DoSomething.org chatbot API for use with Mobile Commons.
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /v1/chatbot` | [Chat](endpoints/chatbot.md#chat)
-`POST /v1/chatbot/sync` | [Sync chatbot content](endpoints/chatbot.md#sync)
-
 
 
 #### DS Campaigns

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -29,6 +29,7 @@ Name | Type | Description
 --- | --- | ---
 `phone` | `string` | **Required.** Our member's mobile number.
 `args` | `string` | An incoming message the member has sent.
+`keyword` | `string` | If set, it's the Mobile Commons keyword that posted to this endpoint.
 `profile_first_name` | `string` | 
 `profile_email` | `string` | 
 `profile_northstar_id` | `string` | Used by CampaignBot to load User - [@todo Create Northstar User if no value exists](https://github.com/DoSomething/gambit/issues/636)

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -20,6 +20,7 @@ const models = {
     'msg_ask_supports_mms',
     'msg_ask_why_participated',
     'msg_invalid_quantity',
+    'msg_member_support',
     'msg_menu_completed',
     'msg_menu_signedup',
     'msg_no_photo_sent',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -134,8 +134,10 @@ function getFirstWord(message) {
 module.exports.getFirstWord = getFirstWord;
 
 
+/**
+ * Returns the uppercase first word of given message.
+ */
 module.exports.getFirstWordUppercase = function (message) {
-  logger.debug(`getFirstWordUppercase:${message}`);
   const isText = message || getFirstWord(message);
   if (!isText) {
     return null;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -135,11 +135,12 @@ module.exports.getFirstWord = getFirstWord;
 
 
 module.exports.getFirstWordUppercase = function (message) {
-  const firstWord = getFirstWord(message);
-  if (!firstWord) {
+  logger.debug(`getFirstWordUppercase:${message}`);
+  const isText = message || getFirstWord(message);
+  if (!isText) {
     return null;
   }
-  return firstWord.toUpperCase();
+  return getFirstWord(message).toUpperCase();
 }
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,6 +133,15 @@ function getFirstWord(message) {
 };
 module.exports.getFirstWord = getFirstWord;
 
+
+module.exports.getFirstWordUppercase = function (message) {
+  const firstWord = getFirstWord(message);
+  if (!firstWord) {
+    return null;
+  }
+  return firstWord.toUpperCase();
+}
+
 /**
  * Determines whether or not the first word in the given message is 'YES' or a
  * variation of it.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -138,11 +138,12 @@ module.exports.getFirstWord = getFirstWord;
  * Returns the uppercase first word of given message.
  */
 module.exports.getFirstWordUppercase = function (message) {
-  const isText = message || getFirstWord(message);
-  if (!isText) {
+  const firstWord = getFirstWord(message);
+  if (!firstWord) {
     return null;
   }
-  return getFirstWord(message).toUpperCase();
+
+  return firstWord.toUpperCase();
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
- Namespaces Mobile Commons specific config variables with a `MOBILECOMMONS_` prefix:
  - `MOBILECOMMONS_OIP_CAMPAIGNBOT`, `MOBILECOMMONS_OIP_DONORSCHOOSEBOT`, `MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ENDED`, `MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ERROR`
- Adds a new `GAMBIT_CMD_MEMBER_SUPPORT` config variable. If the member texts in the value during a CampaignBot conversation, they are opted into a Mobile Commons OIP defined by new config variable `MOBILECOMMONS_OIP_AGENTVIEW`.
  - The AgentView OIP conversation should be set to **NOT** trigger any mData's, which means all subsequent messages the member sends will be added to the Mobile Commons Agent View queue for member support to respond to, until they text in another Mobile Commons keyword.
  - Sends new CampaignBot `member_support` message to the member when they are opted into the Agent View OIP. This message should contain the `{{keyword_continue}}` variable to inform the member how to continue in CampaignBot after they have submitted their support questions.  `{{keyword_continue}}` renders our new `MOBILECOMMONS_KEYWORD_CAMPAIGNBOT`config variable.
  - The `MOBILECOMMONS_KEYWORD_CAMPAIGNBOT` should be set to the keyword defined on our CampaignBot mData, which posts to chatbot without a `campaign` (the same mData that our `MOBILECOMMONS_OIP_CAMPAIGNBOT` posts to). This allows the member to text in a keyword to continue where they left (loading their saved `current_campaign`).
  - The end result of all this makes our `member_support` copy look something like this: 
    
    > Text back your question and I'll do my best to answer back within 24 hours. If you'd like to continue on {{title}}, text back {{keyword_continue}}.
- Adds additional Gambit Jr. support for `{{cmd_reportback}}` and `{{cmd_member_support}}` for Gambit commands to use in CampaignBot messages.  Here's what an example `menu_completed` could read like: 
  
  > Got you down for {{quantity}} {{rb_noun}} {{rb_verb}}. If you have {{rb_verb}} more, text {{cmd_reportback}}. If you have a question, text {{cmd_member_support}}
- Refactors `isCommandCacheClear(req)` and `isCommandReportback(req)` to single `isCommand(req, type)` function with expected `type` values of `cache_clear`, `reportback`, and `member_support`
#### How should this be reviewed?

👀 
#### Relevant tickets
#606
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Added required config vars on staging 
- [x] Tested on staging.
- [ ] Added required config vars on production
