### PR TITLE
Deprecate req.query.campaign

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -80,7 +80,7 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = req.query.campaign || false;
+    const ask = req.body.keyword;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -57,7 +57,27 @@ router.post('/', (req, res) => {
     return res.sendStatus(500);
   }
 
-  let campaignId = req.query.campaign;
+  let campaignId;
+  if (req.body.keyword) {
+    const keyword = req.body.keyword.toUpperCase();
+    switch (keyword) {
+      case 'BOOKBOT':
+        campaignId = 2299;
+        break;
+      case 'BUMBLEBOT':
+        campaignId = 2070;
+        break;
+      case 'LUCKYBOT':
+        campaignId = 2900;
+        break;
+      case 'SLEEVEBOT':
+        campaignId = 2938;
+        break;
+      default:
+        campaignId = null;
+    }
+  }
+
   let campaign;
   if (campaignId) {
     campaign = app.locals.campaigns[campaignId];

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -20,7 +20,6 @@ Name | Type | Description
 Name | Type | Description
 --- | --- | ---
 `bot_type` | `string` | Type of bot to chat with if not CampaignBot, our default. Possible values: `donorschoosebot`, `slothbot`
-`campaign` | `integer` | If set, Gambit starts a CampaignBot conversation for given DS Campaign for the incoming request's User
 `start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
 
 **Input**


### PR DESCRIPTION
#### What's this PR do?
- Hardcodes CampaignBot keyword / campaign map to deprecate query parameters
- We can use a single CampaignBot mData now that requests for all DS Campaigns go to a single `/v1/chatbot` URL.  For each incoming request, we determine which Campaign to load first by checking if the User texted in a CampaignBot keyword, if not we load the Campaign stored on the User's `current_campaign` property.
#### How should this be reviewed?

Locally : set expected `keyword` param and POST to `/v1/chatbot` to test conversation

Staging:
- [x] Deploy to staging
- [x] Deactivate all mData's with a `?campaign=` defined
- [x] Add each keyword from de-activated mData onto the CampaignBot mData's keywords
- [x] Test keywords, conversation
#### Any background context you want to provide?

Next up is adding a Campaign model back in to avoid hardcoding and begin work on #652 
#### Relevant tickets
#655
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
