### PR TITLE
Support multiple Signup keywords per Campaign

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -31,7 +31,7 @@ class CampaignBotController {
   collectReportbackProperty(req, property, ask) {
     this.debug(req, `collectReportbackProperty:${property}`);
 
-    if (ask || req.body.keyword) {
+    if (ask || req.keyword) {
       return this.renderResponseMessage(req, `ask_${property}`);
     }
 
@@ -80,7 +80,7 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = req.body.keyword;
+    const ask = req.keyword;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);
@@ -451,9 +451,15 @@ class CampaignBotController {
     msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
     msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
-    if (req.signup) {
-      msg = msg.replace(/{{keyword}}/i, req.signup.keyword.toUpperCase());
+    if (campaign.keywords) {
+      let keyword = campaign.keywords[0].toUpperCase();
+      if (req.signup && req.signup.keyword) {
+        keyword = req.signup.keyword.toUpperCase();
+      }
+      msg = msg.replace(/{{keyword}}/i, keyword);
+    }
 
+    if (req.signup) {
       let quantity = req.signup.total_quantity_submitted;
       if (req.signup.draft_reportback_submission) {
         quantity = req.signup.draft_reportback_submission.quantity;
@@ -461,7 +467,7 @@ class CampaignBotController {
       msg = msg.replace(/{{quantity}}/gi, quantity);
     }
 
-    const revisiting = req.body.keyword && req.signup && req.signup.draft_reportback_submission;
+    const revisiting = req.keyword && req.signup && req.signup.draft_reportback_submission;
     if (revisiting) {
       // TODO: New bot property for continue draft message
       const continueMsg = 'Picking up where you left off on';

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -173,6 +173,7 @@ class CampaignBotController {
         _id: Number(currentSignup.id),
         user: req.user_id,
         campaign: req.campaign_id,
+        keyword: req.keyword,
         created_at: currentSignup.createdAt,
         // Delete existing draft submission in case we're updating existing
         // Signup model (e.g. if we're handling a clear cache command)
@@ -406,10 +407,11 @@ class CampaignBotController {
    */
   postSignup(req) {
     this.debug(req, 'postSignup');
+    const source = `${process.env.DS_API_POST_SOURCE}-${req.keyword}`;
 
     return app.locals.clients.phoenix.Campaigns
       .signup(req.campaign_id, {
-        source: process.env.DS_API_POST_SOURCE,
+        source,
         uid: req.user.phoenix_id,
       })
       .then((signupId) => ({
@@ -448,9 +450,10 @@ class CampaignBotController {
     msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.msg_rb_confirmation);
     msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
     msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
-    msg = msg.replace(/{{keyword}}/i, campaign.keyword);
 
     if (req.signup) {
+      msg = msg.replace(/{{keyword}}/i, req.signup.keyword.toUpperCase());
+
       let quantity = req.signup.total_quantity_submitted;
       if (req.signup.draft_reportback_submission) {
         quantity = req.signup.draft_reportback_submission.quantity;

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -8,7 +8,7 @@ const mongoose = require('mongoose');
 const schema = new mongoose.Schema({
 
   _id: { type: Number, index: true },
-  keyword: String,
+  keywords: [String],
 
   // Properties cached from DS API.
   title: String,

--- a/api/models/Signup.js
+++ b/api/models/Signup.js
@@ -10,6 +10,7 @@ const schema = new mongoose.Schema({
   _id: { type: Number, index: true },
   user: { type: String, index: true },
   campaign: { type: Number, index: true },
+  keyword: String,
   created_at: Date,
   draft_reportback_submission: {
     type: mongoose.Schema.Types.ObjectId,

--- a/config/locals.js
+++ b/config/locals.js
@@ -59,12 +59,10 @@ function loadCampaign(campaign) {
       logger.debug(`loaded app.locals.campaigns[${campaignDoc._id}]`);
 
       if (campaignDoc.keywords) {
-        campaignDoc.keywords.map((campaignKeyword) => {
+        campaignDoc.keywords.forEach((campaignKeyword) => {
           const keyword = campaignKeyword.toLowerCase();
           app.locals.keywords[keyword] = campaign.id;
           logger.debug(`loaded app.locals.keyword[${keyword}]:${campaign.id}`);
-
-          return true;
         });
       } else {
         logger.warn(`keywords undefined for campaign:${campaign.id} `);

--- a/config/locals.js
+++ b/config/locals.js
@@ -58,12 +58,16 @@ function loadCampaign(campaign) {
       app.locals.campaigns[campaign.id] = campaignDoc;
       logger.debug(`loaded app.locals.campaigns[${campaignDoc._id}]`);
 
-      if (campaignDoc.keyword) {
-        const keyword = campaignDoc.keyword.toUpperCase();
-        app.locals.keywords[keyword] = campaign.id;
-        logger.debug(`loaded app.locals.keyword[${keyword}]:${campaign.id}`);
+      if (campaignDoc.keywords) {
+        campaignDoc.keywords.map((campaignKeyword) => {
+          const keyword = campaignKeyword.toLowerCase();
+          app.locals.keywords[keyword] = campaign.id;
+          logger.debug(`loaded app.locals.keyword[${keyword}]:${campaign.id}`);
+
+          return true;
+        });
       } else {
-        logger.warn(`keyword undefined for campaign:${campaign.id} `);
+        logger.warn(`keywords undefined for campaign:${campaign.id} `);
       }
 
       return campaignDoc;

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -60,6 +60,8 @@ router.post('/', (req, res) => {
   let campaignId;
   if (req.body.keyword) {
     req.keyword = req.body.keyword.toLowerCase(); // eslint-disable-line no-param-reassign
+    logger.debug(`user:${req.user_id} keyword:${req.keyword}`);
+
     campaignId = app.locals.keywords[req.keyword];
     campaign = app.locals.campaigns[campaignId];
     if (!campaign) {

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -59,8 +59,8 @@ router.post('/', (req, res) => {
   let campaign;
   let campaignId;
   if (req.body.keyword) {
-    const keyword = req.body.keyword.toUpperCase();
-    campaignId = app.locals.keywords[keyword];
+    req.keyword = req.body.keyword.toLowerCase(); // eslint-disable-line no-param-reassign
+    campaignId = app.locals.keywords[req.keyword];
     campaign = app.locals.campaigns[campaignId];
     if (!campaign) {
       logger.error(`app.locals.campaigns[${campaignId}] undefined`);


### PR DESCRIPTION
#### What's this PR do?
- Refactors `Campaign.keyword` string property introduced #657 as an array, `keywords`.
- Sets a `req.keyword` as the lowercase keyword, changes `app.locals.keywords` hash map to store lowercase keyword as key value 
- Stores new `Signup.keyword` property to save the keyword used for Signup creation
- Sets the Signup source to `sms-mobilecommons-[keyword]` when posting to Phoenix API
#### How should this be reviewed?

Upon staging deploy, edit each Campaign document in our staging `campaigns` collection and add an array of `keywords`.  Test each keyword works (will need to clear cache to test a 2nd keyword - refs #637)
#### Relevant tickets

Fixes #658
#### Checklist
- [x] Added `keywords` array to Campaign documents in staging DB
- [x] Add any new keywords to the staging mData
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
