### PR TITLE
Adds CampaignBot messages for invalid menu commands + closed campaigns

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -63,11 +63,11 @@ class CampaignBotController {
         } else if (property === 'photo') {
           return this.renderResponseMessage(req, 'ask_caption');
         } else if (property === 'caption') {
-          // TODO: Only ask for why when first reportback.
-          return this.renderResponseMessage(req, 'ask_why_participated');
+          if (!this.hasReportedBack(req)) {
+            return this.renderResponseMessage(req, 'ask_why_participated');
+          }
         }
 
-        // If we made it this far, we're done collecting and ready to submit.
         return this.postReportback(req);
       });
   }
@@ -91,7 +91,9 @@ class CampaignBotController {
     if (!submission.caption) {
       return this.collectReportbackProperty(req, 'caption', ask);
     }
-    if (!submission.why_participated) {
+
+    const askWhy = !this.hasReportedBack(req) && !submission.why_participated;
+    if (askWhy) {
       return this.collectReportbackProperty(req, 'why_participated', ask);
     }
 
@@ -232,6 +234,17 @@ class CampaignBotController {
             new: true,
           });
       });
+  }
+
+  /**
+   * Returns whether current user has submitted a Reportback for the current campaign.
+   * @param {object} req
+   * @return {bool}
+   */
+  hasReportedBack(req) {
+    const result = req.signup && req.signup.total_quantity_submitted;
+
+    return result;
   }
 
   /**

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -143,10 +143,18 @@ router.post('/', (req, res) => {
       }
 
       if (signup.total_quantity_submitted) {
-        return controller.renderResponseMessage(req, 'menu_completed');
+        if (req.keyword) {
+          return controller.renderResponseMessage(req, 'menu_completed');
+        }
+        // If we're this far, member didn't text back Reportback or Member Support commands.
+        return controller.renderResponseMessage(req, 'invalid_cmd_completed');
       }
 
-      return controller.renderResponseMessage(req, 'menu_signedup');
+      if (req.keyword) {
+        return controller.renderResponseMessage(req, 'menu_signedup');
+      }
+
+      return controller.renderResponseMessage(req, 'invalid_cmd_signedup');
     })
     .then(msg => {
       controller.debug(req, `sendMessage:${msg}`);

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -134,6 +134,12 @@ router.post('/', (req, res) => {
         return controller.renderResponseMessage(req, 'member_support');
       }
 
+      if (campaign.status === 'closed') {
+        controller.debug(req, 'campaign closed');
+
+        return controller.renderResponseMessage(req, 'campaign_closed');
+      }
+
       if (signup.draft_reportback_submission) {
         return controller.continueReportbackSubmission(req);
       }

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -18,6 +18,7 @@ const models = {
     'msg_ask_photo',
     'msg_ask_quantity',
     'msg_ask_why_participated',
+    'msg_campaign_closed',
     'msg_invalid_cmd_completed',
     'msg_invalid_cmd_signedup',
     'msg_invalid_quantity',

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -18,6 +18,8 @@ const models = {
     'msg_ask_photo',
     'msg_ask_quantity',
     'msg_ask_why_participated',
+    'msg_invalid_cmd_completed',
+    'msg_invalid_cmd_signedup',
     'msg_invalid_quantity',
     'msg_member_support',
     'msg_menu_completed',


### PR DESCRIPTION
#### What's this PR do?
- Adds `msg_invalid_cmd_signedup` and `msg_invalid_cmd_completed` CampaignBot properties to send if Member texts back an invalid menu response to `msg_menu_signedup` or `msg_menu_completed`
- Responds with a `msg_campaign_closed` message if our Member's saved `current_campaign` has status `closed` (or if Member texts keyword of a closed Campaign -- edge-case when `CAMPAIGNBOT_CAMPAIGNS` is misconfigured and includes id of a closed Campaign)
- Only ask for Reportback `why_participated` if its Member's first Reportback Submission for the selected Campaign
#### How should this be reviewed?
- I'll be adding the Campaign id (and keyword) of a closed Campaign to staging to verify `msg_campaign_closed`.
- Text any non-command at the Signed up and Completed menus to verify `msg_invalid_cmd_signedup` and `msg_invalid_cmd_completed` messages are sent
#### Any background context you want to provide?
- Example `msg_invalid_cmd_completed`:
  ![didnt understand](https://cloud.githubusercontent.com/assets/1236811/19296556/61706aaa-8ff1-11e6-901b-1abe3f336239.jpeg)
- Example `msg_campaign_closed`:
  ![no soup for you](https://cloud.githubusercontent.com/assets/1236811/19296568/6c668098-8ff1-11e6-8bf8-0cb24409504c.jpeg)
- Example [Gambit Jr. CampaignBot response](http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/campaignbots/41):

<img width="647" alt="screen shot 2016-10-11 at 8 35 29 pm" src="https://cloud.githubusercontent.com/assets/1236811/19296693/81038644-8ff2-11e6-850f-8549001e4d58.png">
#### Relevant tickets

Fixes #660
#### Checklist
- [x] Documentation added for new features/changed endpoints -- updated help text in [Gambit Jr. webform](http://dev-gambit-jr.pantheonsite.io/wp-admin/post.php?post=41&action=edit)
- [x] Tested on staging.

cc @jamjensen @classicfreddie 
