### PR TITLE
Northstar User registration + Mobile Commons profile sync

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -168,7 +168,6 @@ class CampaignBotController {
    * Wrapper function for logger.error(error)
    */
   error(req, err) {
-    logger.error(err);
     logger.error(`${this.loggerPrefix(req)} ${err}:${err.stack}`);
   }
 
@@ -247,8 +246,7 @@ class CampaignBotController {
 
         return this.cacheUser(user);
       })
-      .catch((err) => {
-        logger.error(err);
+      .catch(() => {
         logger.debug(`could not getUser type:${type} id:${id}`);
 
         return null;
@@ -522,9 +520,6 @@ class CampaignBotController {
         this.debug(req, `created user:${user.id}`);
 
         return this.cacheUser(user);
-      })
-      .catch((err) => {
-        logger.error(err);
       });
   }
 

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -233,7 +233,7 @@ class CampaignBotController {
   }
 
   /**
-   * Gets User from DS API if exists for given req.user_id, else creates new User.
+   * Gets User from DS API if exists for given type/id, else creates new User.
    * @param {object} req
    * @return {object} - User model
    */
@@ -511,7 +511,8 @@ class CampaignBotController {
     data.source = DS_API_POST_SOURCE;
     data.password = helpers.generatePassword(data.mobile);
     if (!data.email) {
-      data.email = `${data.mobile}@${process.env.DS_API_DEFAULT_USER_EMAIL}`;
+      const defaultEmail = process.env.DS_API_DEFAULT_USER_EMAIL || 'mobile.import';
+      data.email = `${data.mobile}@${defaultEmail}`;
     }
 
     return app.locals.clients.northstar.Users

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -399,6 +399,9 @@ class CampaignBotController {
     if (req.body.profile_id) {
       data.mobilecommons_id = req.body.profile_id;
     }
+    if (req.body.profile_postal_code) {
+      data.addr_zip = req.body.profile_postal_code;
+    }
 
     return data;
   }
@@ -495,8 +498,7 @@ class CampaignBotController {
 
     const data = this.parseMobilecommonsProfile(req);
     data.source = DS_API_POST_SOURCE;
-    // TODO: Encrypt me.
-    data.password = 'password';
+    data.password = helpers.generatePassword(data.mobile);
     if (!data.email) {
       data.email = `${data.mobile}@${process.env.DS_API_DEFAULT_USER_EMAIL}`;
     }

--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -517,9 +517,7 @@ class CampaignBotController {
     return app.locals.clients.northstar.Users
       .create(data)
       .then((user) => {
-        /* eslint-disable no-param-reassign */
-        req.user_id = user.id;
-        /* eslint-enable no-param-reassign */
+        req.user_id = user.id; // eslint-disable-line no-param-reassign
         this.debug(req, `created user:${user.id}`);
 
         return this.cacheUser(user);

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -12,15 +12,12 @@ const mobilecommons = rootRequire('lib/mobilecommons');
  * Handle chatbot conversations.
  */
 router.post('/', (req, res) => {
-  // TODO: Handle when Northstar ID doesn't exist.
   /* eslint-disable no-param-reassign */
-  req.user_id = req.body.profile_northstar_id;
-  req.user_mobile = req.body.phone;
   req.incoming_message = req.body.args;
   req.incoming_image_url = req.body.mms_image_url;
   /* eslint-enable no-param-reassign */
 
-  logger.debug(`user:${req.user_id} msg:${req.incoming_message} img:${req.incoming_image_url}`);
+  logger.debug(`msg:${req.incoming_message} img:${req.incoming_image_url}`);
 
   const botType = req.query.bot_type;
 
@@ -60,7 +57,7 @@ router.post('/', (req, res) => {
   let campaignId;
   if (req.body.keyword) {
     req.keyword = req.body.keyword.toLowerCase(); // eslint-disable-line no-param-reassign
-    logger.debug(`user:${req.user_id} keyword:${req.keyword}`);
+    logger.debug(`keyword:${req.keyword}`);
 
     campaignId = app.locals.keywords[req.keyword];
     campaign = app.locals.campaigns[campaignId];
@@ -79,7 +76,7 @@ router.post('/', (req, res) => {
   }
 
   return controller
-    .loadUser(req.user_id)
+    .loadUser(req)
     .then(user => {
       controller.debug(req, `loaded user:${user._id}`);
 

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -127,7 +127,7 @@ router.post('/', (req, res) => {
 
         if (!campaignId) {
           // TODO: Send to non-existent start menu to select a campaign.
-          logger.error(`user:${req.user_id} current_campaign undefined`);
+          logger.error(`user:${req.user._id} current_campaign undefined`);
         }
 
         campaign = app.locals.campaigns[campaignId];

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 /**
  * Imports.
  */
+const crypto = require('crypto');
 const logger = rootRequire('lib/logger');
 
 module.exports = {
@@ -198,3 +199,14 @@ module.exports.getLetters = function(message) {
   return message.replace(/[^a-zA-Z]/g, '');
 }
 
+/**
+ * Returns hash for given string with DS API assword key. 
+ * @param {string} text
+ * @return {string}
+ */
+module.exports.generatePassword = function(text) {
+  return crypto.createHmac('sha1', process.env.DS_API_PASSWORD_KEY)
+    .update(text)
+    .digest('hex')
+    .substring(0,6);
+}

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -238,12 +238,6 @@ exports.optout = function(args) {
  *     Mobile Commons Custom Fields on our member's profile.
  */
 exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
-  if (process.env.MOBILECOMMONS_DISABLED) {
-    logger.warn('MOBILECOMMONS_DISABLED');
-
-    return;
-  }
-
   if (typeof optInPath === 'undefined') {
     logger.error('mobilecommons.chatbot undefined optInPath user:%s msgText:%s', 
       member, msgTxt);

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -238,6 +238,12 @@ exports.optout = function(args) {
  *     Mobile Commons Custom Fields on our member's profile.
  */
 exports.chatbot = function(member, optInPath, msgTxt, profileFields) {
+  if (process.env.MOBILECOMMONS_DISABLED) {
+    logger.warn('MOBILECOMMONS_DISABLED');
+
+    return;
+  }
+
   if (typeof optInPath === 'undefined') {
     logger.error('mobilecommons.chatbot undefined optInPath user:%s msgText:%s', 
       member, msgTxt);


### PR DESCRIPTION
#### What's this PR do?

Finishes Northstar User integration. 
- If an incoming request `req` sent from a Mobile Commons member doesn't contain a `req.body.profile_northstar_id`, get Northstar User by mobile number (or create User if none exists) then update their Mobile Commons `northstar_id` Profile Custom Field when we post  back to Mobile Commons in `sendSMSResponse(req, msg)`.
- Also adds support for a `MOBILECOMMONS_DISABLED` environment variable for development 
#### How should this be reviewed?

Test existing Northstar user:
- Remove your `northstar_id` Custom Field value on your Mobile Commons profile
- Text a staging keyword to CampaignBot
- Verify your Mobile Commons profile is updated with your `northstar_id`

Test new Northstar registration:
- Remove your `northstar_id` Custom Field value on your Mobile Commons profile
- Remove your mobile number from your Northstar User via Aurora webform, and also from your Phoenix User via Phoenix user edit webform
- Text a staging keyword to CampaignBot
- Verify a new user is created in Aurora, Phoenix, and its Northstar ID exists on your Mobile Commons profile
#### Relevant tickets

Fixes #636
#### Checklist
- [x] Add `DS_API_PASSWORD_KEY` and `DS_API_DEFAULT_USER_EMAIL` to staging
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [x] Add `DS_API_PASSWORD_KEY` and `DS_API_DEFAULT_USER_EMAIL` to production
