### PR TITLE
DonorsChooseBot model 

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -166,7 +166,7 @@ class CampaignBotController {
     this.debug(req, 'createReportbackSubmission');
     const scope = req;
 
-    return app.locals.db.reportbackSubmissions
+    return app.locals.db.reportback_submissions
       .create({
         campaign: req.campaign._id,
         user: req.user._id,

--- a/api/controllers/DonorsChooseBotController.js
+++ b/api/controllers/DonorsChooseBotController.js
@@ -357,7 +357,7 @@ DonorsChooseBotController.prototype.postDonation = function(member, project) {
         school_city: project.city,
         school_state: project.state
       };
-      app.locals.db.donorsChooseDonations.create(donationLogData).then(function(doc) {
+      app.locals.db.donorschoose_donations.create(donationLogData).then(function(doc) {
         logger.log('debug', 'dc.createDonationDoc success:%s', donation);
       }, promiseErrorCallback('dc.createDonationDoc user: ' + member.phone));
     };

--- a/api/models/CampaignBot.js
+++ b/api/models/CampaignBot.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Models a CampaignBot.
+ * Models a Gambit Jr. CampaignBot.
  */
 const mongoose = require('mongoose');
 

--- a/api/models/DonorsChooseBot.js
+++ b/api/models/DonorsChooseBot.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Models a Gambit Jr. DonorsChooseBot.
+ */
+const mongoose = require('mongoose');
+
+const schema = new mongoose.Schema({
+
+  _id: { type: Number, index: true },
+  msg_ask_email: String,
+  msg_ask_first_name: String,
+  msg_donation_success: String,
+  msg_error_generic: String,
+  msg_invalid_email: String,
+  msg_invalid_first_name: String,
+  msg_invalid_zip: String,
+  msg_project_link: String,
+  msg_max_donations_reached: String,
+  msg_search_start: String,
+  msg_search_no_results: String,
+
+});
+
+module.exports = function (connection) {
+  return connection.model('donorschoosebots', schema);
+};

--- a/config/locals.js
+++ b/config/locals.js
@@ -41,8 +41,6 @@ function getBot(endpoint, id) {
     });
 }
 
-
-
 /**
  * Upserts given Phoenix campaign to campaign model, saves to app.locals.campaign[campaign.id].
  */
@@ -143,7 +141,7 @@ module.exports.loadBot = function (endpoint, id) {
       }
 
       return bot;
-    })
+    });
 };
 
 /**
@@ -162,27 +160,6 @@ module.exports.loadCampaigns = function () {
       logger.debug(`loadCampaigns found ${campaigns.length} campaigns`);
 
       return campaigns.map(campaign => loadCampaign(campaign));
-    });
-};
-
-/**
- * Loads app.locals.controllers.donorsChooseBot from Gambit Jr API.
- */
-module.exports.loadDonorsChooseBotController = function () {
-  const donorsChooseBotId = process.env.DONORSCHOOSEBOT_ID;
-  logger.debug(`loadDonorsChooseBot:${donorsChooseBotId}`);
-
-  // TODO: Needs to handle connection error (add DonorsChooseBot model, findDonorsChooseBot)
-  return gambitJunior
-    .get('donorschoosebots', donorsChooseBotId)
-    .then((donorsChooseBot) => {
-      logger.debug(`gambitJunior found donorsChooseBot:${donorsChooseBotId}`);
-
-      const DonorsChooseBotController = rootRequire('api/controllers/DonorsChooseBotController');
-      app.locals.controllers.donorsChooseBot = new DonorsChooseBotController(donorsChooseBot);
-      logger.info('loaded app.locals.controllers.donorsChooseBot');
-
-      return app.locals.controllers.donorsChooseBot;
     });
 };
 

--- a/config/locals.js
+++ b/config/locals.js
@@ -153,23 +153,31 @@ module.exports.getPhoenixClient = function () {
 };
 
 /**
+ * Gets given bot from API, or loads from cache if error.
+ */
+function loadBot(endpoint, id) {
+  logger.debug(`locals.loadBot endpoint:${endpoint} id:${id}`);
+
+  return getBot(endpoint, id)
+    .then((bot) => {
+      if (!bot) {
+        logger.debug('getBot undefined');
+
+        return findBot(endpoint, id);
+      }
+
+      return bot;
+    })
+}
+
+/**
  * Loads app.locals.controllers.campaignBot from Gambit Jr API.
  */
 module.exports.loadCampaignBotController = function () {
   logger.debug('loadCampaignBotController');
   const CAMPAIGNBOT_ID = process.env.CAMPAIGNBOT_ID || 41;
-  const endpoint = 'campaignbots';
 
-  return getBot('campaignbots', CAMPAIGNBOT_ID)
-    .then((campaignBot) => {
-      if (!campaignBot) {
-        logger.debug('getCampaignBot undefined');
-
-        return findBot(CAMPAIGNBOT_ID);
-      }
-
-      return campaignBot;
-    })
+  return loadBot('campaignbots', CAMPAIGNBOT_ID)
     .then((campaignBot) => {
       const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
       app.locals.controllers.campaignBot = new CampaignBotController(campaignBot);

--- a/config/locals.js
+++ b/config/locals.js
@@ -91,12 +91,12 @@ module.exports.getModels = function (conn) {
   models.campaigns = rootRequire('api/models/Campaign')(conn);
   models.campaignbots = rootRequire('api/models/CampaignBot')(conn);
   models.donorschoosebots = rootRequire('api/models/DonorsChooseBot')(conn);
-  // TODO: Change keys to machine names.
-  models.donorsChooseDonations = rootRequire('api/models/DonorsChooseDonation')(conn);
-  models.legacyReportbacks = rootRequire('api/legacy/reportback/reportbackModel')(conn);
-  models.reportbackSubmissions = rootRequire('api/models/ReportbackSubmission')(conn);
+  models.donorschoose_donations = rootRequire('api/models/DonorsChooseDonation')(conn);
+  models.reportback_submissions = rootRequire('api/models/ReportbackSubmission')(conn);
   models.signups = rootRequire('api/models/Signup')(conn);
   models.users = rootRequire('api/models/User')(conn);
+  // TBDeleted
+  models.legacyReportbacks = rootRequire('api/legacy/reportback/reportbackModel')(conn);
 
   return models;
 };

--- a/lib/gambit-junior.js
+++ b/lib/gambit-junior.js
@@ -11,51 +11,17 @@ const logger = rootRequire('lib/logger');
  */
 const defaultUri = 'http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2';
 const uri = process.env.GAMBIT_JR_API_BASEURI || defaultUri;
-const models = {
-  campaignbots: [
-    'id',
-    'msg_ask_caption',
-    'msg_ask_photo',
-    'msg_ask_quantity',
-    'msg_ask_why_participated',
-    'msg_campaign_closed',
-    'msg_invalid_cmd_completed',
-    'msg_invalid_cmd_signedup',
-    'msg_invalid_quantity',
-    'msg_member_support',
-    'msg_menu_completed',
-    'msg_menu_signedup',
-    'msg_no_photo_sent',
-  ],
-  donorschoosebots: [
-    'id',
-    'msg_ask_email',
-    'msg_ask_first_name',
-    'msg_ask_zip',
-    'msg_donation_success',
-    'msg_error_generic',
-    'msg_invalid_email',
-    'msg_invalid_first_name',
-    'msg_invalid_zip',
-    'msg_project_link',
-    'msg_max_donations_reached',
-    'msg_search_start',
-    'msg_search_no_results',
-  ],
-};
 
 /**
- * Helper function to parse data object to given endpoint bot.
+ * Helper function to parse a Gambit Jr. bot.
  */
-function parseBot(data, endpoint) {
-  logger.verbose(`parseBot endpoint:${endpoint} id:${data.id}`);
+function parseBot(data) {
+  if (!data.id) {
+    throw new Error('Cannot parse bot.');
+  }
+  logger.verbose(`parseBot id:${data.id}`);
 
-  const bot = {};
-  models[endpoint].forEach((property) => {
-    bot[property] = data[property];
-  });
-
-  return bot;
+  return data;
 }
 
 /**
@@ -67,7 +33,7 @@ function parseGet(response, endpoint) {
     throw new Error('Cannot parse API get response.');
   }
 
-  return parseBot(response.body, endpoint);
+  return parseBot(response.body);
 }
 
 /**
@@ -80,7 +46,7 @@ function parseIndex(response, endpoint) {
     throw new Error('Cannot parse API index response.');
   }
 
-  return response.body.map(row => parseBot(row, endpoint));
+  return response.body.map(row => parseBot(row));
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -16,10 +16,10 @@ http.globalAgent.maxSockets = 100;
 const logger = rootRequire('lib/logger');
 
 // Used by legacy reportback endpoint:
-const phoenix = rootRequire('lib/phoenix')();
+const legacyPhoenix = rootRequire('lib/phoenix')();
 const username = process.env.DS_PHOENIX_API_USERNAME;
 const password = process.env.DS_PHOENIX_API_PASSWORD;
-phoenix.userLogin(username, password, (err, response) => {
+legacyPhoenix.userLogin(username, password, (err, response) => {
   if (err) {
     logger.error(err);
   }
@@ -39,19 +39,19 @@ app.use(require('connect-multiparty')());
 const errorHandler = require('errorhandler');
 app.use(errorHandler());
 
-const locals = rootRequire('config/locals');
+const loader = rootRequire('config/locals');
 
 require('./config/router');
 
 app.locals.clients = {};
 
-app.locals.clients.northstar = locals.getNorthstarClient();
+app.locals.clients.northstar = loader.getNorthstarClient();
 if (!app.locals.clients.northstar) {
   logger.error('app.locals.clients.northstar undefined');
   process.exit(1);
 }
 
-app.locals.clients.phoenix = locals.getPhoenixClient();
+app.locals.clients.phoenix = loader.getPhoenixClient();
 if (!app.locals.clients.phoenix) {
   logger.error('app.locals.clients.phoenix undefined');
   process.exit(1);
@@ -62,18 +62,25 @@ mongoose.Promise = global.Promise;
 
 const uri = process.env.DB_URI || 'mongodb://localhost/ds-mdata-responder';
 const conn = mongoose.createConnection(uri);
-app.locals.db = locals.getModels(conn);
+app.locals.db = loader.getModels(conn);
 
 conn.on('connected', () => {
   logger.info(`conn.readyState:${conn.readyState}`);
 
   app.locals.controllers = {};
+  const campaignBot = loader.loadBot('campaignbots',  process.env.CAMPAIGNBOT_ID || 41)
+    .then((campaignBot) => {
+      const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
+      app.locals.controllers.campaignBot = new CampaignBotController(campaignBot);
+
+      return app.locals.controllers.campaignBot; 
+    });
 
   const promises = [
-    locals.loadCampaigns(),
-    locals.loadCampaignBotController(),
-    locals.loadDonorsChooseBotController(),
-    locals.loadLegacyConfigs(),
+    campaignBot,
+    loader.loadCampaigns(),
+    loader.loadDonorsChooseBotController(),
+    loader.loadLegacyConfigs(),
   ];
 
   Promise.all(promises).then(() => {

--- a/server.js
+++ b/server.js
@@ -68,18 +68,29 @@ conn.on('connected', () => {
   logger.info(`conn.readyState:${conn.readyState}`);
 
   app.locals.controllers = {};
-  const campaignBot = loader.loadBot('campaignbots',  process.env.CAMPAIGNBOT_ID || 41)
-    .then((campaignBot) => {
-      const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
-      app.locals.controllers.campaignBot = new CampaignBotController(campaignBot);
 
-      return app.locals.controllers.campaignBot; 
+  const campaignBot = loader.loadBot('campaignbots', process.env.CAMPAIGNBOT_ID || 41)
+    .then((bot) => {
+      const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
+      app.locals.controllers.campaignBot = new CampaignBotController(bot);
+      logger.info('loaded app.locals.controllers.campaignBot');
+
+      return app.locals.controllers.campaignBot;
+    });
+
+  const donorsChooseBot = loader.loadBot('donorschoosebots', process.env.DONORSCHOOSEBOT_ID || 31)
+    .then((bot) => {
+      const DonorsChooseBotController = rootRequire('api/controllers/DonorsChooseBotController');
+      app.locals.controllers.donorsChooseBot = new DonorsChooseBotController(bot);
+      logger.info('loaded app.locals.controllers.donorsChooseBot');
+
+      return app.locals.controllers.donorsChooseBot;
     });
 
   const promises = [
     campaignBot,
+    donorsChooseBot,
     loader.loadCampaigns(),
-    loader.loadDonorsChooseBotController(),
     loader.loadLegacyConfigs(),
   ];
 
@@ -89,5 +100,9 @@ conn.on('connected', () => {
     return app.listen(port, () => {
       logger.info(`Gambit is listening on port:${port} env:${process.env.NODE_ENV}.`);
     });
+  })
+  .catch((err) => {
+    logger.error(err);
+    process.exit(1);
   });
 });


### PR DESCRIPTION
#### What's this PR do?
- Adds a `DonorsChooseBot`model to cache `donorschoosebots` in case of Gambit Jr. failure (leftover task from #666)
- Refactors `locals.getCampaignBotController` and `locals.getDonorsChooseBotController` functions into smaller `getBot(endpoint, id)` and `findBot(endpoint, id)` functions.
- Cleans up unnecessary Gambit Jr response parsing per https://github.com/DoSomething/gambit-jr/pull/1
#### How should this be reviewed?
- Start app without a `GAMBIT_JR_API_BASEURI` and verify the `donorschoosebots` collection is populated with a document for your local `DONORSCHOOSEBOT_ID`
- Set an invalid `GAMBIT_JR_API_BASEURI` and restart app. Verify that the `app.locals.controllers.donorsChooseBot` loads its `donorschoosebot` from the newly inserted document
#### Relevant tickets

Fixes #662
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
