### PR TITLE
Send Chatbot Signup confirmation upon receiving non-Gambit Signups 

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -296,7 +296,7 @@ class CampaignBotController {
           if (!user) {
             this.debug(req, `no doc for user:${userID}`);
 
-            return app.locals.db.users.get('id', userID);
+            return app.locals.db.users.lookup('id', userID);
           }
           this.debug(req, `found doc for user:${userID}`);
 

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -27,7 +27,8 @@ const schema = new mongoose.Schema({
   msg_invalid_quantity: String,
   msg_member_support: String,
   msg_menu_completed: String,
-  msg_menu_signedup: String,
+  msg_menu_signedup_external: String,
+  msg_menu_signedup_gambit: String,
   msg_no_photo_sent: String,
 
 });

--- a/api/models/CampaignBot.js
+++ b/api/models/CampaignBot.js
@@ -18,7 +18,8 @@ const schema = new mongoose.Schema({
   msg_invalid_quantity: String,
   msg_member_support: String,
   msg_menu_completed: String,
-  msg_menu_signedup: String,
+  msg_menu_signedup_external: String,
+  msg_menu_signedup_gambit: String,
   msg_no_photo_sent: String,
 
 });

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -118,7 +118,7 @@ router.post('/', (req, res) => {
         scope.user = user;
         scope.signup = currentSignup;
         scope.campaign = app.locals.campaigns[currentSignup.campaign];
-        const responseMsg = controller.renderResponseMessage(scope, 'menu_signedup');
+        const responseMsg = controller.renderResponseMessage(scope, 'menu_signedup_external');
 
         return res.send(gambitResponse(responseMsg));
       });
@@ -220,7 +220,7 @@ router.post('/', (req, res) => {
       }
 
       if (scope.keyword) {
-        return controller.renderResponseMessage(scope, 'menu_signedup');
+        return controller.renderResponseMessage(scope, 'menu_signedup_gambit');
       }
 
       return controller.renderResponseMessage(scope, 'invalid_cmd_signedup');

--- a/config/router-chatbot.js
+++ b/config/router-chatbot.js
@@ -118,9 +118,11 @@ router.post('/', (req, res) => {
         scope.user = user;
         scope.signup = currentSignup;
         scope.campaign = app.locals.campaigns[currentSignup.campaign];
-        const responseMsg = controller.renderResponseMessage(scope, 'menu_signedup_external');
 
-        return res.send(gambitResponse(responseMsg));
+        const msg = controller.renderResponseMessage(scope, 'menu_signedup_external');
+        postMobileCommonsProfile(scope, msg);
+
+        return res.send(gambitResponse(msg));
       });
   }
 


### PR DESCRIPTION
#### What's this PR do?

Followup to #675 to send member a CampaignBot Signup confirmation message if the `chatbot` endpoint receives a request for a non `sms-mobilecommons` Signup.
- Refactors the CampaignBot `msg_menu_signedup` into 2 new properties:
  - `msg_menu_signedup_gambit` -- Confirmation message to send when member texts in a keyword to Gambit to signup
  - `msg_menu_signedup_external` -- Confirmation message to send when Gambit receives a Signup request from a service like Quicksilver
- Fixes epic bug introduced in #675 -- rename outlier `app.users.db.get` as `app.users.db.lookup`
#### How should this be reviewed?
- Text in a Signup keyword to CampaignBot to create a new Signup (need to unsignup if you're already signedup), and verify the `msg_menu_signedup_gambit` message is sent.
- Post a `signup_id` and `signup_source` to the staging `chatbot` endpoint for your User -- confirm the `msg_menu_signedup_external` message is sent.
#### Any background context you want to provide?

I've changed the Gambit Jr. edit form to display the machine names of the CampaignBot properties, to hopefully help make the [CampaignBot override](https://github.com/DoSomething/gambit/wiki/Chatbot#overriding-responses) process easier (just copy the label in Gambit Jr, vs inspecting the API response to figure out what property to override)

<img width="1137" alt="screen shot 2016-10-23 at 9 28 26 pm" src="https://cloud.githubusercontent.com/assets/1236811/19633536/be12e998-9967-11e6-89d1-1b604379591a.png">
#### Relevant tickets
#642
#### Checklist
- [x] Documentation added for new features/changed endpoints -- updated help text in Gambit Jr
- [x] Tested on staging.
