### PR TITLE
Adds GET campaigns endpoint

### DIFF
--- a/config/router.js
+++ b/config/router.js
@@ -50,7 +50,13 @@ router.get('/v1/campaigns/:id', (req, res) => {
   return app.locals.db.campaigns
     .findById(req.params.id)
     .exec()
-    .then(campaign => res.send({ data: campaign }))
+    .then(campaign => {
+      if (!campaign) {
+        return res.sendStatus(404);
+      }
+
+      return res.send({ data: campaign });
+    })
     .catch(error => res.send(error));
 });
 

--- a/config/router.js
+++ b/config/router.js
@@ -21,13 +21,41 @@ router.use((req, res, next) => {
 });
 
 /**
- * Chatbot routes.
+ * Chatbot.
  */
 const chatbotRouter = rootRequire('config/router-chatbot');
 router.use('/v1/chatbot', chatbotRouter);
 
 /**
- * Legacy routes.
+ * Campaigns.
+ */
+router.get('/v1/campaigns', (req, res) => {
+  const findClause = {};
+  if (req.query.campaignbot) {
+    const campaignConfigVar = process.env.CAMPAIGNBOT_CAMPAIGNS;
+    const campaignIDs = campaignConfigVar.split(',').map(id => Number(id));
+    findClause._id = { $in: campaignIDs };
+  }
+
+  return app.locals.db.campaigns
+    .find(findClause)
+    .exec()
+    .then(campaigns => res.send({ data: campaigns }))
+    .catch(error => res.send(error));
+});
+
+router.get('/v1/campaigns/:id', (req, res) => {
+  logger.debug(`get campaign ${req.params.id}`);
+
+  return app.locals.db.campaigns
+    .findById(req.params.id)
+    .exec()
+    .then(campaign => res.send({ data: campaign }))
+    .catch(error => res.send(error));
+});
+
+/**
+ * Legacy.
  */
 const campaignRouter = rootRequire('legacy/ds-routing');
 const reportbackRouter = rootRequire('legacy/reportback');

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,17 +1,22 @@
-# Gambit
-
-This is __Gambit__, a DoSomething.org chatbot API for use with Mobile Commons.
+# API
 
 
-## Endpoints
+## Chatbot
 
-#### Chatbot
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
 `POST /v1/chatbot` | [Chat](endpoints/chatbot.md#chat)
 
 
-#### DS Campaigns
+## Campaigns
+
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`GET /v1/campaigns` | [Retrieve all campaigns](endpoints/campaigns.md#retrieve-all-campaigns)
+`GET /v1/campaigns/:id` | [Retrieve a campaign](endpoints/campaigns.md#retrieve-a-campaigns)
+
+
+## Legacy
 
 > :memo: We're looking to deprecate these, so don't get too attached!
 

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -1,0 +1,23 @@
+# Campaigns
+
+## Retrieve all Campaigns 
+
+```
+GET /v1/campaigns
+```
+
+Returns index of Gambit Campaign models stored in `campaigns` collection.
+
+**Parameters**
+
+Name | Type | Description
+--- | --- | ---
+`start` | `boolean` | If set to `true`, only return Campaigns defined in `CAMPAIGNBOT_CAMPAIGNS`
+
+## Retrieve a Campaign
+
+```
+GET /v1/campaigns/:id
+```
+
+Returns a single Gambit Campaign model for given Campaign ID.

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -12,7 +12,7 @@ Returns index of Gambit Campaign models stored in `campaigns` collection.
 
 Name | Type | Description
 --- | --- | ---
-`start` | `boolean` | If set to `true`, only return Campaigns defined in `CAMPAIGNBOT_CAMPAIGNS`
+`campaignbot` | `boolean` | If set to `true`, only return Campaigns defined in `CAMPAIGNBOT_CAMPAIGNS`
 
 ## Retrieve a Campaign
 


### PR DESCRIPTION
#### What's this PR do?
- Adds a `/v1/campaigns` to expose Campaign documents
- Supports `campaignbot=true` query parameter to filter index by Campaigns defined in `CAMPAIGNBOT_CAMPAIGNS` config var
#### How should this be reviewed?

👀, review staging mLab DB upon deploy.

Still need to sort out #673 to ensure Campaign documents have Mobile Commons Groups (some don't if we already have created an ID in a diferent environment)
#### Relevant tickets
- Fixes #677
- Refs work needed for #673 
#### Checklist
- [x] Tested on staging.
