### PR TITLE
Add Campaign.fact_problem, refactor locals.js as Mongoose static methods

### DIFF
--- a/api/controllers/CampaignBotController.js
+++ b/api/controllers/CampaignBotController.js
@@ -427,6 +427,7 @@ class CampaignBotController {
     msg = msg.replace(/{{br}}/gi, '\n');
     msg = msg.replace(/{{title}}/gi, campaign.title);
     msg = msg.replace(/{{tagline}}/i, campaign.tagline);
+    msg = msg.replace(/{{fact_problem}}/gi, campaign.fact_problem);
     msg = msg.replace(/{{rb_noun}}/gi, campaign.rb_noun);
     msg = msg.replace(/{{rb_verb}}/gi, campaign.rb_verb);
     msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.msg_rb_confirmation);

--- a/api/models/Campaign.js
+++ b/api/models/Campaign.js
@@ -16,6 +16,7 @@ const campaignSchema = new mongoose.Schema({
   // Properties cached from DS API.
   title: String,
   current_run: Number,
+  fact_problem: String,
   msg_rb_confirmation: String,
   rb_noun: String,
   rb_verb: String,
@@ -49,6 +50,7 @@ function parsePhoenixCampaign(phoenixCampaign) {
     tagline: phoenixCampaign.tagline,
     title: phoenixCampaign.title,
     current_run: phoenixCampaign.currentCampaignRun.id,
+    fact_problem: phoenixCampaign.facts.problem,
     msg_rb_confirmation: phoenixCampaign.reportbackInfo.confirmationMessage,
     rb_noun: phoenixCampaign.reportbackInfo.noun,
     rb_verb: phoenixCampaign.reportbackInfo.verb,

--- a/api/models/DonorsChooseBot.js
+++ b/api/models/DonorsChooseBot.js
@@ -4,8 +4,11 @@
  * Models a Gambit Jr. DonorsChooseBot.
  */
 const mongoose = require('mongoose');
+const Promise = require('bluebird');
+const gambitJunior = rootRequire('lib/junior');
+const logger = app.locals.logger;
 
-const schema = new mongoose.Schema({
+const donorsChooseBotSchema = new mongoose.Schema({
 
   _id: { type: Number, index: true },
   msg_ask_email: String,
@@ -22,6 +25,32 @@ const schema = new mongoose.Schema({
 
 });
 
+/**
+ * Query Gambit Jr API for given DonorsChooseBot and store.
+ */
+donorsChooseBotSchema.statics.lookupByID = function (id) {
+  const model = this;
+
+  return new Promise((resolve, reject) => {
+    logger.debug(`donorsChooseBotSchema.lookupByID:${id}`);
+
+    return gambitJunior
+      .get('donorschoosebots', id)
+      .then(response => {
+        const data = response;
+        data._id = Number(response.id);
+        data.id = undefined;
+
+        return model
+          .findOneAndUpdate({ _id: data._id }, data, { upsert: true, new: true })
+          .exec()
+          .then(donorsChooseBot => resolve(donorsChooseBot))
+          .catch(error => reject(error));
+      })
+      .catch(error => reject(error));
+  });
+};
+
 module.exports = function (connection) {
-  return connection.model('donorschoosebots', schema);
+  return connection.model('donorschoosebots', donorsChooseBotSchema);
 };

--- a/config/locals.js
+++ b/config/locals.js
@@ -24,8 +24,8 @@ module.exports.getModels = function (conn) {
 /**
  * Gets given bot from API, or loads from cache if error.
  */
-module.exports.loadBot = function (botType, id) {
-  const endpoint = `${botType}s`;
+module.exports.loadBot = function (type, id) {
+  const endpoint = `${type}s`;
   logger.debug(`locals.loadBot endpoint:${endpoint} id:${id}`);
   const model = app.locals.db[endpoint];
 

--- a/config/locals.js
+++ b/config/locals.js
@@ -75,10 +75,9 @@ module.exports.loadBot = function (botType, id) {
   const model = app.locals.db[endpoint];
 
   return model.lookupByID(id)
-    .then((bot) => {
-      if (bot) {
-        return bot;
-      }
+    .then((bot) => bot)
+    .catch((err) => {
+      logger.error(`${endpoint}.lookupByID:${id} failed`);
 
       return app.locals.db[endpoint]
         .findById(id)

--- a/server.js
+++ b/server.js
@@ -55,6 +55,11 @@ if (!app.locals.logger) {
   process.exit(1);
 }
 
+if (!process.env.CAMPAIGNBOT_CAMPAIGNS) {
+  app.locals.logger.error('process.env.CAMPAIGNBOT_CAMPAIGNS undefined');
+  process.exit(1);
+}
+
 const loader = require('./config/locals');
 
 require('./router');
@@ -98,7 +103,6 @@ if (!app.locals.clients.phoenix) {
   process.exit(1);
 }
 
-
 conn.on('connected', () => {
   logger.info(`conn.readyState:${conn.readyState}`);
 
@@ -109,7 +113,7 @@ conn.on('connected', () => {
   app.locals.keywords = {};
 
   const loadCampaigns = app.locals.db.campaigns
-    .lookupByIDs(process.env.CAMPAIGNBOT_CAMPAIGNS || '2070,2299')
+    .lookupByIDs(process.env.CAMPAIGNBOT_CAMPAIGNS)
     .then((campaigns) => {
       logger.debug(`app.locals.db.campaigns.lookupByIDs found ${campaigns.length} campaigns`);
 

--- a/server.js
+++ b/server.js
@@ -121,9 +121,7 @@ conn.on('connected', () => {
    */
   app.locals.controllers = {};
 
-  const campaignBotID = process.env.CAMPAIGNBOT_ID || 41;
-  const campaignBot = app.locals.db.campaignbots
-    .lookupByID(campaignBotID)
+  const campaignBot = loader.loadBot('campaignbot', process.env.CAMPAIGNBOT_ID || 41)
     .then((bot) => {
       const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
       app.locals.controllers.campaignBot = new CampaignBotController(bot);
@@ -133,7 +131,7 @@ conn.on('connected', () => {
     })
     .catch(err => logger.error(err));
 
-  const donorsChooseBot = loader.loadBot('donorschoosebots', process.env.DONORSCHOOSEBOT_ID || 31)
+  const donorsChooseBot = loader.loadBot('donorschoosebot', process.env.DONORSCHOOSEBOT_ID || 31)
     .then((bot) => {
       const DonorsChooseBotController = rootRequire('api/controllers/DonorsChooseBotController');
       app.locals.controllers.donorsChooseBot = new DonorsChooseBotController(bot);

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ global.rootRequire = function (name) {
 
 const express = require('express');
 const http = require('http');
+const Promise = require('bluebird');
 
 // Default is 5. Increasing # of concurrent sockets per host.
 http.globalAgent.maxSockets = 100;
@@ -120,14 +121,17 @@ conn.on('connected', () => {
    */
   app.locals.controllers = {};
 
-  const campaignBot = loader.loadBot('campaignbots', process.env.CAMPAIGNBOT_ID || 41)
+  const campaignBotID = process.env.CAMPAIGNBOT_ID || 41;
+  const campaignBot = app.locals.db.campaignbots
+    .lookupByID(campaignBotID)
     .then((bot) => {
       const CampaignBotController = rootRequire('api/controllers/CampaignBotController');
       app.locals.controllers.campaignBot = new CampaignBotController(bot);
       logger.info('loaded app.locals.controllers.campaignBot');
 
       return app.locals.controllers.campaignBot;
-    });
+    })
+    .catch(err => logger.error(err));
 
   const donorsChooseBot = loader.loadBot('donorschoosebots', process.env.DONORSCHOOSEBOT_ID || 31)
     .then((bot) => {


### PR DESCRIPTION
#### What's this PR do?
- Refactors a bunch of `load`, `get`, `parse` functions from `config/locals.js` into the relevant Model classes as static methods
- Adds support to render a Phoenix Campaign's `facts.problem` copy as a `{{fact_problem}}` Liquid tag.
#### How should this be reviewed?

I'll make the update in Gambit Jr. to add `{{fact_problem}}` into the `msg_menu_signedup_gambit` to test. Text in a keyword and verify the fact problem is rendered.
#### Any background context you want to provide?

Last big Mongoose static/instance refactor coming up is the Signup class, breaking down the monolithic `getCurrentSignup`
#### Relevant tickets
- Fixes #684 
- Refs similar Mongoose static/instance refactoring in #682
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
