### PR TITLE
Adds missing property to DonorsChooseBot model

### DIFF
--- a/app/controllers/DonorsChooseBotController.js
+++ b/app/controllers/DonorsChooseBotController.js
@@ -84,6 +84,8 @@ DonorsChooseBotController.prototype.chatbot = function(request, response) {
     return;
   }
 
+  // TODO: Don't send response until we deliver the message, and return the message in response
+  // like we do for CampaignBot.
   response.send();
   var firstWord = null;
 

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -13,6 +13,7 @@ const donorsChooseBotSchema = new mongoose.Schema({
   _id: { type: Number, index: true },
   msg_ask_email: String,
   msg_ask_first_name: String,
+  msg_ask_zip: String,
   msg_donation_success: String,
   msg_error_generic: String,
   msg_invalid_email: String,


### PR DESCRIPTION
#### What's this PR do?

Adds missing `msg_ask_zip` property -- missed in #667  
#### How should this be reviewed?

Clear your Donation Count, First Name, Email, and Zip from your Mobile Commons Profile.

Locally,  post to `chatbot?bot_type=donorschoosebot&start=true` without any profile fields passed. Confirm ask zip code message is sent. Continue testing by posting to the `chatbot?bot_type=donorschoosebot` endpoint and including each profile field that you're submitting values for. So your next request
- don't include params and send a zip code as `args`. confirm asked for first name
- next, include `profile_postal_code` and send first name value as `args`. confirm asked for email
- next, include `profile_first_name` and send an email value as `args`. Confirm the next message sent is searching for a project to donate to.

Staging: with a clear mobile commons profile, simply text staging keyword in to verify conversation goes as expected.
#### Any background context you want to provide?

Sadness
#### Relevant tickets

Fixes #688
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
