### PR TITLE
Always lookup User ID and current Signup ID, don't trust the cache

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -64,7 +64,7 @@ signupSchema.statics.lookupByID = function (signupID) {
 
     return app.locals.clients.northstar
       .Signups.get(signupID)
-      .then(northstarSignup => {
+      .then((northstarSignup) => {
         logger.debug(`northstar.Signups.get:${signupID} success`);
         const data = parseNorthstarSignup(northstarSignup);
 
@@ -87,8 +87,8 @@ signupSchema.statics.lookupCurrentForUserAndCampaign = function (user, campaign)
 
     return app.locals.clients.northstar
       .Signups.index({ user: user._id, campaigns: campaign._id })
-      .then(northstarSignups => {
-        if (!northstarSignups.length) {
+      .then((northstarSignups) => {
+        if (northstarSignups.length < 1) {
           return resolve(false);
         }
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -22,8 +22,6 @@ const userSchema = new mongoose.Schema({
   email: String,
   role: String,
   first_name: String,
-  // Hash table to store current signups: e.g. campaigns[campaignId] = signupId;
-  campaigns: { type: mongoose.Schema.Types.Mixed, default: {} },
   // Campaign the user is currently participating in via chatbot.
   current_campaign: Number,
 
@@ -116,23 +114,6 @@ userSchema.methods.postMobileCommonsProfileUpdate = function (optInPathID, msgTx
   };
 
   return mobilecommons.profile_update(this.mobile, optInPathID, data);
-};
-
-/**
- * Set given signup on user's campaigns hash map, sets signup.campaign to user.current_campaign.
- */
-userSchema.methods.setCurrentCampaign = function (signup) {
-  const user = this;
-
-  return new Promise((resolve, reject) => {
-    logger.debug(`setCurrentSignup user:${user._id} campaigns[${signup.campaign}]:${signup.id}`);
-
-    user.campaigns[signup.campaign] = signup.id;
-    user.current_campaign = signup.campaign;
-    return user.save()
-      .then(updatedUser => resolve(updatedUser))
-      .catch(error => reject(error));
-  });
 };
 
 module.exports = function (connection) {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -122,21 +122,18 @@ userSchema.statics.createForMobileCommonsRequest = function (req) {
 };
 
 /**
- * Updates user's Mobile Commons Profile to send msgTxt as SMS via given Opt-in Path oip.
+ * Updates MC Profile gambit_chatbot_response Custom Field with given msgTxt to deliver over SMS.
+ * @param {number} optInPathID - ID of the Mobile Commons Opt-in Path that will send a message
+ * @param {string} msgText - text message content to send to User
  */
-userSchema.methods.postMobileCommonsProfileUpdate = function (req, oip, msgTxt) {
+userSchema.methods.postMobileCommonsProfileUpdate = function (optInPathID, msgTxt) {
   const data = {
-    // Target Opt oip needs to render gambit_chatbot_response Custom Field in Liquid to send msg.
+    // The MC Opt-in Path Conversation needs to render gambit_chatbot_response value as Liquid tag.
     // @see https://github.com/DoSomething/gambit/wiki/Chatbot#mobile-commons
     gambit_chatbot_response: msgTxt,
   };
 
-  if (!req.body.profile_northstar_id) {
-    // Save it to avoid future Northstar GET users requests in subsequent incoming chatbot requests.
-    data.northstar_id = this._id;
-  }
-
-  return mobilecommons.profile_update(this.mobile, oip, data);
+  return mobilecommons.profile_update(this.mobile, optInPathID, data);
 };
 
 /**

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -74,7 +74,11 @@ router.post('/', (req, res) => {
         if (err && err.status === 404) {
           logger.debug(`app.locals.db.users.lookup could not find mobile:${req.body.phone}`);
 
-          return resolve(app.locals.db.users.createForMobileCommonsRequest(req));
+          const user = app.locals.db.users.post({
+            mobile: req.body.phone,
+            mobilecommons_id: req.profile_id,
+          });
+          return resolve(user);
         }
         return reject(err);
       });

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -183,6 +183,7 @@ router.post('/', (req, res) => {
       }
 
       if (scope.signup.draft_reportback_submission) {
+        logger.debug(`draft_reportback_submission:${scope.signup.draft_reportback_submission._id}`);
         return controller.continueReportbackSubmission(scope);
       }
 
@@ -212,6 +213,7 @@ router.post('/', (req, res) => {
       return scope.user.save();
     })
     .then(() => {
+      logger.debug(`saved user.current_campaign:${scope.campaign._id}`);
       scope.user.postMobileCommonsProfileUpdate(mobileCommonsOIP, scope.response_message);
 
       return res.send(gambitResponse(scope.response_message));

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -205,11 +205,16 @@ router.post('/', (req, res) => {
       return controller.renderResponseMessage(scope, 'invalid_cmd_signedup');
     })
     .then((msg) => {
-      controller.debug(scope, `sendMessage:${msg}`);
-      scope.user.setCurrentCampaign(scope.signup);
-      scope.user.postMobileCommonsProfileUpdate(mobileCommonsOIP, msg);
+      scope.response_message = msg;
+      controller.debug(scope, `chatbotResponseMessage:${msg}`);
+      // Save to continue conversation with future mData requests that don't contain a keyword.
+      scope.user.current_campaign = scope.campaign._id;
+      return scope.user.save();
+    })
+    .then(() => {
+      scope.user.postMobileCommonsProfileUpdate(mobileCommonsOIP, scope.response_message);
 
-      return res.send(gambitResponse(msg));
+      return res.send(gambitResponse(scope.response_message));
     })
     .catch(CampaignNotFoundError, () => {
       logger.error('CampaignNotFoundError');

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -27,7 +27,7 @@ Name | Type | Description
 `phone` | `string` | **Required.** Mobile number that sent incoming message.
 `args` | `string` | Incoming text sent.
 `mms_image_url` | `string` | Incoming image sent.
-`keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that the triggered incoming Mobile Commons mData request.
+`keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that triggered the incoming mData POST.
 `profile_first_name` | `string` | Only used by `donorschoosebot`
 `profile_email` | `string` | Only used by `donorschoosebot`
 `profile_postal_code` | `string` |  Only used by `donorschoosebot`
@@ -40,7 +40,6 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
      --data-urlencode "phone=5555555511" \
-     --data-urlencode "profile_northstar_id=5547be89469c64ec7d8b518d" \
      --data-urlencode "keyword=slothieboi"
 ````
 </details>

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -1,7 +1,6 @@
 # Chatbot
 
-Our Mobile Commons Chatbot mData will POST here to send the message a User texted to the DoSomething shortcode. Gambit determines how to respond to the message, and delivers a SMS response back to User 
-by posting the response message to a Custom Field on their Mobile Commons Profile.
+Currently only implemented for use by a Mobile Commons mData POST request.
 
 ```
 POST /v1/chatbot
@@ -21,19 +20,18 @@ Name | Type | Description
 `start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
 
 **Input**
-Parameter names are defined by the data included in a Mobile Commons mData POST request.
+Field names are defined by the data included in a Mobile Commons mData POST request.
 
 Name | Type | Description
 --- | --- | ---
-`phone` | `string` | **Required.** Our member's mobile number.
-`args` | `string` | Incoming message the member has sent.
+`phone` | `string` | **Required.** Mobile number that sent incoming message.
+`args` | `string` | Incoming text sent.
+`mms_image_url` | `string` | Incoming image sent.
 `keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that the triggered incoming Mobile Commons mData request.
-`mms_image_url` | `string` | URL of incoming image member as has sent.
-`profile_first_name` | `string` | 
-`profile_email` | `string` | 
-`profile_northstar_id` | `string` | 
-`profile_postal_code` | `string` | 
-`profile_ss2016_donation_count` | `string` | Used by `donorschoose` bots to limit # of donations. This parameter name can be changed by `DONORSCHOOSE_DONATION_FIELDNAME`
+`profile_first_name` | `string` | Only used by `donorschoosebot`
+`profile_email` | `string` | Only used by `donorschoosebot`
+`profile_postal_code` | `string` |  Only used by `donorschoosebot`
+`profile_ss2016_donation_count` | `string` | Only used by `donorschoosebot` to store # of donations. This parameter name can be changed by `DONORSCHOOSE_DONATION_FIELDNAME`
 
 <details>
 <summary>**Example Request**</summary>

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -39,7 +39,7 @@ exports.profile_update = function(phone, optInPathId, customFields) {
     return;
   }
 
-  logger.log('debug', 'mobilecommons.profile_update for user:%s oip:%s customFields:%s', phone, optInPathId, JSON.stringify(customFields));
+  logger.log('debug', 'mobilecommons.profile_update for mobile:%s oip:%s customFields:%s', phone, optInPathId, JSON.stringify(customFields));
 
   var url = 'https://secure.mcommons.com/api/profile_update';
   var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
@@ -67,10 +67,10 @@ exports.profile_update = function(phone, optInPathId, customFields) {
   var trace = new Error().stack;
   var callback = function(error, response, body) {
     if (error) {
-      logger.error('mobilecommons.profile_update user:%s form:%s error:%s', phone, JSON.stringify(postData.form), error);
+      logger.error('mobilecommons.profile_update mobile:%s form:%s error:%s', phone, JSON.stringify(postData.form), error);
     }
     else if (response && response.statusCode != 200) {
-      logger.error('mobilecommons.profile_update for user:'
+      logger.error('mobilecommons.profile_update for mobile:'
         + phone + ' | form data: ' + JSON.stringify(postData.form)
         + '| with code: ' + response.statusCode
         + ' | body: ' + body + ' | stack: ' + trace);

--- a/server.js
+++ b/server.js
@@ -122,7 +122,7 @@ conn.on('connected', () => {
         app.locals.campaigns[campaignID] = campaign;
         logger.debug(`loaded app.locals.campaigns[${campaignID}]`);
 
-        if (!campaign.keywords.length) {
+        if (campaign.keywords.length < 1) {
           logger.warn(`no keywords defined for campaign:${campaignID}`);
         }
         campaign.keywords.forEach((campaignKeyword) => {


### PR DESCRIPTION
#### What's this PR do?
- Refactors `app/routes/chatbot` to **GET** `/users` for the incoming `req.body.mobile` sent in each mData `chatbot` API request, instead of finding existing User document based on value saved to the `req.body.profile_northstar_id` field -- which was implemented in attempt to cut down on API requests. Any performance wins we gained by avoiding that GET request don't seem worth the inconsistent NS ID Profile value issues we're seeing in #691.
- Creates new user with only incoming `req.body.mobile` and `req.body.mobilecommons_id` values -- no longer post `first_name`, `email`, or `postal_code` if we have it. See "background context I want to provide".
- No longer saves Northstar ID to Mobile Commons Profile, as Gambit no longer needs it.
- Same for Signups: Always query for an ID, don't store anything to `User.campaigns` anymore. Only save the `user.current_campaign` upon successful request, so we know which campaign to load if user returns without a keyword included.
#### How should this be reviewed?
- Clear your Northstar ID profile field value, and text into Thor or Prod CampaignBot. Verify Northstar ID profile field is not updated (and that you're getting CampaignBot responses as expected)
- Should be able to freely text between Thor and Production campaigns without trouble -- which suggests it'd make sense to add either a `@thor: Hey it's me`prefix progamatically to all messages sent from Thor Gambit, or add/configure a separate new [Thor CampaignBot](http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/campaignbots/41) to better distinguish which environment you're chatbotting with.
#### Any background context you want to provide?

I experienced an odd bug today where saving my first name as "Go" in the DonorsChooseBot flow and then texting into production CampaignBot was causing my `user` to have a null phone number (yet my phone number and User ID were correct).  No idea why, but seems easier to just disregard any MC Profile info besides the critical info (`phone` being #1, `profile_id` seems reasonable to trust).

I initially included First Name, Email, and Postal Code profile fields in **POST** `users` thinking, "why not submit the info if we collect it for Science Sleuth?", but between HEROGATE (users providing false info to unlock donations) and this First Name mismatch bug I ran into -- seems best to [KISS](https://en.wikipedia.org/wiki/KISS_principle) for v1.
#### Relevant tickets
- Fixes #691 
- Fixes #679
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
