### PR TITLE
Fixes Signups API, renames exception classes

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -307,6 +307,9 @@ class CampaignBotController {
 
     const botProperty = `msg_${msgType}`;
     let msg = this.bot[botProperty];
+    if (!campaign) {
+      return msg;
+    }
     // Check if campaign has an override defined.
     if (campaign[botProperty]) {
       msg = campaign[botProperty];

--- a/app/exceptions/CampaignClosedError.js
+++ b/app/exceptions/CampaignClosedError.js
@@ -1,5 +1,0 @@
-'use strict';
-
-class CampaignClosedError extends Error {}
-
-module.exports = CampaignClosedError;

--- a/app/exceptions/CampaignNotFoundError.js
+++ b/app/exceptions/CampaignNotFoundError.js
@@ -1,5 +1,0 @@
-'use strict';
-
-class CampaignNotFoundError extends Error {}
-
-module.exports = CampaignNotFoundError;

--- a/app/exceptions/NotFoundError.js
+++ b/app/exceptions/NotFoundError.js
@@ -1,11 +1,5 @@
 'use strict';
 
-class NotFoundError extends Error {
-
-  constructor(message) {
-    super(message);
-  }
-
-}
+class NotFoundError extends Error {}
 
 module.exports = NotFoundError;

--- a/app/exceptions/NotFoundError.js
+++ b/app/exceptions/NotFoundError.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class NotFoundError extends Error {
+
+  constructor(message) {
+    super(message);
+  }
+
+}
+
+module.exports = NotFoundError;

--- a/app/exceptions/UnprocessibleEntityError.js
+++ b/app/exceptions/UnprocessibleEntityError.js
@@ -1,11 +1,5 @@
 'use strict';
 
-class UnprocessibleEntityError extends Error {
-
-  constructor(message) {
-    super(message);
-  }
-
-}
+class UnprocessibleEntityError extends Error {}
 
 module.exports = UnprocessibleEntityError;

--- a/app/exceptions/UnprocessibleEntityError.js
+++ b/app/exceptions/UnprocessibleEntityError.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class UnprocessibleEntityError extends Error {
+
+  constructor(message) {
+    super(message);
+  }
+
+}
+
+module.exports = UnprocessibleEntityError;

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -56,23 +56,24 @@ function parseNorthstarSignup(northstarSignup) {
 /**
  * Get given Signup ID from DS API then store.
  */
-signupSchema.statics.lookupByID = function (signupID) {
+signupSchema.statics.lookupById = function (id) {
   const model = this;
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.lookupByID:${signupID}`);
+    logger.debug(`Signup.lookupById:${id}`);
 
     return app.locals.clients.northstar
-      .Signups.get(signupID)
+      .Signups.get(id)
       .then((northstarSignup) => {
-        logger.debug(`northstar.Signups.get:${signupID} success`);
+        logger.debug(`northstar.Signups.get:${id} success`);
         const data = parseNorthstarSignup(northstarSignup);
 
-        return model.findOneAndUpdate({ _id: signupID }, data, { upsert: true, new: true })
+        return model.findOneAndUpdate({ _id: id }, data, { upsert: true, new: true })
           .exec()
           .then(signup => resolve(signup))
           .catch(error => reject(error));
-      });
+      })
+      .catch(err => reject(err));
   });
 };
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -8,8 +8,8 @@ const router = express.Router(); // eslint-disable-line new-cap
 
 const logger = app.locals.logger;
 const Promise = require('bluebird');
-const CampaignClosedError = require('../exceptions/CampaignClosedError');
-const CampaignNotFoundError = require('../exceptions/CampaignNotFoundError');
+const NotFoundError = require('../exceptions/NotFoundError');
+const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 
 /**
  * Formats our Express return response.
@@ -101,16 +101,16 @@ router.post('/', (req, res) => {
           campaign = app.locals.campaigns[campaignID];
 
           if (!campaign) {
-            logger.error(`keyword app.locals.campaigns[${campaignID}] undefined`);
-            throw new CampaignNotFoundError();
+            const msg = `Keyword received does not have a campaign associated with it.`;
+            throw new NotFoundError(msg);
           }
 
           if (campaign.status === 'closed') {
             // Store campaign to render in closed message.
             scope.campaign = campaign;
             // TODO: Include this message to the CampaignClosedError.
-            logger.error(`keyword:${scope.keyword} is set to closed campaign:${campaignID}`);
-            throw new CampaignClosedError();
+            const msg = `Keyword received for closed campaign ${campaignID}.`;
+            throw new UnprocessibleEntityError(msg);
           }
 
           return resolve(campaign);
@@ -122,8 +122,8 @@ router.post('/', (req, res) => {
 
         if (!campaign) {
           // TODO: Send to non-existent start menu to select a campaign.
-          logger.error(`user:${user._id} current_campaign ${campaignID} undefined`);
-          throw new CampaignNotFoundError();
+          const msg = `User ${user._id} current_campaign ${campaignID} not found in CampaignBot.`;
+          throw new NotFoundError(msg);
         }
 
         return resolve(campaign);
@@ -218,13 +218,8 @@ router.post('/', (req, res) => {
 
       return res.send(gambitResponse(scope.response_message));
     })
-    .catch(CampaignNotFoundError, () => {
-      logger.error('CampaignNotFoundError');
-
-      return res.sendStatus(404);
-    })
-    .catch(CampaignClosedError, () => {
-      logger.error('CampaignClosedError');
+    .catch(NotFoundError, (err) => res.status(404).send(err.message))
+    .catch(UnprocessibleEntityError, () => {
       const msg = controller.renderResponseMessage(scope, 'campaign_closed');
       scope.user.postMobileCommonsProfileUpdate(mobileCommonsOIP, msg);
 

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
+const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 const logger = app.locals.logger;
 
@@ -82,6 +83,7 @@ router.post('/', (req, res) => {
 
       return sendResponse(res, 200, chatbotMessage);
     })
+    .catch(NotFoundError, err => sendResponse(res, 404, err.message))
     .catch(UnprocessibleEntityError, err => sendResponse(res, 422, err.message))
     .catch(err => sendResponse(res, 500, err.message));
 });

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -2,7 +2,8 @@
 
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
-const CampaignNotFoundError = require('../exceptions/CampaignNotFoundError');
+const NotFoundError = require('../exceptions/NotFoundError');
+const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 const logger = app.locals.logger;
 
 function successResponse(msg) {
@@ -30,46 +31,59 @@ router.post('/', (req, res) => {
   logger.debug(`POST /v1/signups { id:${signupID}, source:${source} }`);
 
   if (source === process.env.DS_API_POST_SOURCE) {
-    const msg = `Already sent confirmation for signup ${signupID} with source ${source}.`;
+    const msg = `CampaignBot already sent confirmation for signup ${signupID} (source==${source}).`;
 
     return res.send(successResponse(msg));
   }
 
   let currentSignup;
+  let currentCampaign;
+  let chatbotMsg;
 
   return app.locals.db.signups
     .lookupByID(signupID)
     .then((signup) => {
       currentSignup = signup;
       if (!app.locals.campaigns[signup.campaign]) {
-        throw new CampaignNotFoundError();
+        const msg = `Campaign ID ${signup.campaign} is not enabled for CampaignBot.`;
+        throw new UnprocessibleEntityError(msg);
       }
 
       return app.locals.db.users.lookup('id', currentSignup.user);
     })
     .then((user) => {
       if (!user) {
-        return res.status(500).send({ error: 'Cannot find user for signup' });
+        const msg = `Northstar 404 for user {currentSignup.user} on signup ${signupID}.`;
+        throw new NotFoundError(msg);
       }
 
-      return user.setCurrentCampaign(currentSignup);
-    })
-    .then((user) => {
+      if (!user.mobile) {
+        throw new UnprocessibleEntityError('Missing user mobile.');
+      }
+
       const scope = req;
       scope.user = user;
       scope.signup = currentSignup;
-      scope.campaign = app.locals.campaigns[currentSignup.campaign];
+      currentCampaign = app.locals.campaigns[currentSignup.campaign];
+
       const controller = app.locals.controllers.campaignBot;
-      const msg = controller.renderResponseMessage(scope, 'menu_signedup_external');
-      user.postMobileCommonsProfileUpdate(req, process.env.MOBILECOMMONS_OIP_CHATBOT, msg);
+      chatbotMsg = controller.renderResponseMessage(scope, 'menu_signedup_external');
 
-      return res.send(successResponse(msg));
+      user.current_campaign = currentCampaign._id;
+      return user.save();
     })
-    .catch(CampaignNotFoundError, () => {
-      const msg = `Campaign ${currentSignup.campaign} is not a CampaignBot campaign.`;
-      logger.warn(msg);
+    .then((user) => {
+      user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_CHATBOT, chatbotMsg);
 
-      return res.status(422).send({ error: msg });
+      return res.send(successResponse(chatbotMsg));
+    })
+    .catch(NotFoundError, (err) => {
+ 
+      return res.status(404).send({ error: err.msg });
+    })
+    .catch(UnprocessibleEntityError, (err) => {
+ 
+      return res.status(422).send({ error: err.msg });
     });
 });
 


### PR DESCRIPTION
#### What's this PR do?
- Fixes #696 and restores POST `signups` endpoint
- Renames `app/exceptions` as general classes
#### How should this be reviewed?

Test POST to `/v1/signups` with these params:
- id=2309254 source=`'mobileapp_ios'` --  Signup 2309254 is for my user for Campaign 46, currently running on staging CampaignBot. Shoudl return 200 with the rendered CampaignBot `msg_menu_signedup_external` message. Please use with care -- this will send a text to my number 📲  Test sending to your own phone by passing a Signup for your user and for a CampaignBot campaign, with a non `'sms-mobilecommons'` source.
- id=2309254 source=`'sms-mobilecommons'` - Should return a 208 for already sent, Signups with source `'sms-mobilecommons'` should not trigger sending a SMS confirmation
- id=1978786 source=`'mobileapp_ios'` - Should return 422, it's a Signup for a Campaign not running on CampaignBot 
- id=`'abc'` source=`'mobileapp_ios'` - Should return 404
#### Relevant tickets

Fixes #696
#### Checklist
- [x] Tested on staging.
