### PR TITLE
Adds campaignbot bool property to Campaigns API response

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -142,10 +142,16 @@ campaignSchema.methods.createMobileCommonsGroups = function () {
  * Returns formatted Campaign object to return in campaigns endpoint.
  */
 campaignSchema.methods.formatApiResponse = function () {
+  let campaignBotCampaign = false;
+  if (app.locals.campaigns[this._id]) {
+    campaignBotCampaign = true;
+  }
+
   // TODO: Add all other properties.
   const data = {
     id: this._id,
     title: this.title,
+    campaignbot: campaignBotCampaign,
     status: this.status,
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,


### PR DESCRIPTION
#### What's this PR do?
Adds `campaignbot` property to better indicate when a Campaign is running on CampaignBot, besides checking the query param for index -- http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns?campaignbot=true 

#### How should this be reviewed?
Will deploy to staging, view response in browser

#### Any background context you want to provide?
This is more of a convenience visibility feature vs anything required by QS.

#### Relevant tickets
https://github.com/DoSomething/mbc-registration-mobile/issues/48#issuecomment-257364753

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
