### PR TITLE
Lookup current Signup in Signups.lookupCurrent for real

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -350,6 +350,11 @@ class CampaignBotController {
       msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;
     }
 
+    const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
+    if (senderPrefix) {
+      msg = `${senderPrefix} ${msg}`;
+    }
+
     return msg;
   }
 

--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -187,33 +187,7 @@ class CampaignBotController {
 
     const configName = `GAMBIT_CMD_${type.toUpperCase()}`;
     const configValue = process.env[configName];
-    if (!configValue) {
-      logger.warn(`${this.loggerPrefix(req)} process.env.${configName} is undefined`);
-
-      return false;
-    }
-
     const result = this.parseCommand(req) === configValue.toUpperCase();
-
-    if (result && type === 'clear_cache') {
-      if (!this.isStaff(req.user)) {
-        logger.warn(`${this.loggerPrefix(req)} unauthorized command clear_cache`);
-
-        return false;
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * TODO: Move to User as instance function.
-   * Returns whether given user is DS staff.
-   * @param {object} user
-   * @return {bool}
-   */
-  isStaff(user) {
-    const result = user.role && (user.role === 'staff' || user.role === 'admin');
 
     return result;
   }

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -121,6 +121,12 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
   });
 };
 
+/**
+ * Posts Signup to DS API.
+ * @param {User} user - User model.
+ * @param {Campaign} campaign - Campaign model.
+ * @param {string} keyword - Keyword used to trigger Campaign Signup.
+ */
 signupSchema.statics.post = function (user, campaign, keyword) {
   const model = this;
 

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -55,6 +55,7 @@ function parseNorthstarSignup(northstarSignup) {
 
 /**
  * Get given Signup ID from DS API then store.
+ * @param {number} id - DS Signup id.
  */
 signupSchema.statics.lookupById = function (id) {
   const model = this;
@@ -86,9 +87,11 @@ signupSchema.statics.lookupById = function (id) {
 };
 
 /**
- * Gets current Signup for given User and Campaign from DS API.
+ * Gets current Signup for given User / Campaign from DS API, stores if found. Returns false if not.
+ * @param {User} user - User model.
+ * @param {Campaign} campaign - Campaign model.
  */
-signupSchema.statics.lookupCurrentForUserAndCampaign = function (user, campaign) {
+signupSchema.statics.lookupCurrent = function (user, campaign) {
   const model = this;
 
   return new Promise((resolve, reject) => {

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -144,7 +144,7 @@ router.post('/', (req, res) => {
         scope.campaign = campaign;
 
         return app.locals.db.signups
-          .lookupCurrentForUserAndCampaign(scope.user, scope.campaign)
+          .lookupCurrent(scope.user, scope.campaign)
           .then((currentSignup) => {
             if (currentSignup) {
               logger.debug(`loadSignup found signup:${currentSignup._id}`);


### PR DESCRIPTION
#### What's this PR do?
* Renames `Signup.lookupCurrentForUserAndCampaign(user, campaign)` function to just `Signup.lookupCurrent(user, campaign)`

* Adds check in `lookupCurrent` to return the first Signup found where `currentRun.current`, instead of just blindly returning the first Signup found. This was always a TODO for later -- and [that day has come, as Don't Be A Sucker is running on CampaignBot in its 2nd run](https://dosomething.slack.com/archives/gambit/p1478037777001803)

* Removes check for deprecated Clear Cache command. We no longer cache what the User's current signup is (removed in #692)

* Adds a new `GAMBIT_CHATBOT_RESPONSE_PREFIX` to as an environment indicator. Will set it to `@thor:` for staging to close #710

#### How should this be reviewed?

##### Current Signup

* Signup for a CampaignBot Campaign via staging SMS keyword.
* In Phoenix Thor, close the Campaign you signed up for and re-open it on a new run.
* Signup again for the Campaign via staging keyword -- verify a new Signup ID is created.

<img width="1393" alt="screen shot 2016-11-01 at 8 46 59 pm" src="https://cloud.githubusercontent.com/assets/1236811/19916285/e15588e2-a075-11e6-97c2-30e0ee499658.png">


##### Environment indicator / Chatbot Response Prefix

I've deployed this to staging -- should get messages back with a prefix of `@thor:` upon texting a  staging keyword.

![slack for ios upload](https://cloud.githubusercontent.com/assets/1236811/19932161/3a8a49d8-a0cc-11e6-8a4b-4f1e750a0fe2.jpeg)



#### Relevant tickets
* Fixes #639 
* Fixes #710 

#### Checklist
- [x] Tested on staging.
