### PR TITLE
Starts on chatbot broadcast query parameter

### DIFF
--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -16,6 +16,7 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
+`broadcast` | `boolean` | For use with `campaignbot` -- if set, parses User's sent message as either Yes or No response to Signup for whatever the `CAMPAIGNBOT_BROADCAST_CAMPAIGN` config var is set to.
 `bot_type` | `string` | Defaults to `campaignbot`, accepts `donorschoosebot`
 `start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
 


### PR DESCRIPTION
#### What's this PR do?

* Refactors the `loadCampaign` and `loadSignup` Promises in `routes/chatbot` as a single `return` statement

* If a `broadcast` query parameter is set, inspect current User's incoming message as a Yes or No to determine whether to Signup for `CAMPAIGNBOT_BROADCAST_CAMPAIGN`, a new config var to set per broadcast in #651 

    * If user says Yes, signup for the campaign and deliver the `msg_menu_signedup_gambit`

    * If user says No, returns placeholder copy for now and opts the User into Agent View to field any further responses. Does this by throwing a new `Error` for now for sake of simplicity (vs using Promise.cancel, or returning `null` or `false` throughout the Promise chain).


* `routes/chatbot` cleanup:

    *  Use `scope.oip` instead of `mobileCommonsOIP` to DRY

    * Rename `campaignID` as `campaignId` per https://github.com/DoSomething/gambit/pull/697#discussion_r85598802


#### How should this be reviewed?

* Locally can post to `/v1/chatbot?broadcast=true` and respond with according yes/no responses.

* Staging, we'll need to broadcast to our team internally following these steps: 

    * [ ] Create a new CampaignBot Broadcast mData  that posts to Staging `/v1/chatbot?broadcast=true`

    * [ ] Deploy this branch to staging, and set `CAMPAIGNBOT_BROADCAST_CAMPAIGN` to a Campaign ID currently running on CampaignBot

    * [ ] Send broadcast with Conversation set to trigger our new CampaignBot Broadcast mData


* Also ensure sure normal routing of texting in a Campign Signup keyword works 🆗 

#### Any background context you want to provide?

**NOTE**: If user says no to the broadcast, we're still creating a Northstar User for them. We could change this up to just simply return the `'broadcast_declined'` message -- but this seemed to fall into the category of Why not create a User for them. We'll want to clear this with our API and data teams.

Next up:
* [ ] If all looks good, prep a Poduction CampaignBot Broadcast mData posting to prod Gambit `/v1/chatbot?broadcast=true` 
* [ ] Add CampaignBot property to avoid hardcoding "broadcast declined" copy
* [ ] Add a `messages` collection to store incoming `broadcast_id` and whether User signed up or declined the broadcast message they were sent. Refs #698 

#### Relevant tickets
#651 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
