### PR TITLE
Begins DonorsChooseBot refactor

### DIFF
--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -32,6 +32,21 @@ function sendResponse(res, code, msgType, profileUpdate) {
   return helpers.sendResponse(res, 200, responseMessage);
 }
 
+/**
+ * This route was built for the Science Sleuth SMS Game on Mobile Commons, where the final game OIP
+ * triggers an mData that posts here, to donate to DonorsChoose project on behalf of the player.
+ *
+ * DonorsChooseBot asks for the sender's zip code, first name, and email to post a donation to the
+ * DonorsChoose API, donating to the first project it finds closest to the sender's zip code.
+ *
+ * If the Mobile Commons Profile doesn't have a value saved for zip, first name, or email, we send
+ * a message back to the User prompting for it (and a 200 response back to Mobile Commons, since we
+ * know how to respond the sender's message and have posted to their profile to respond by SMS).
+ *
+ * DonorsChooseBot was the predecessor to CampaignBot - we didn't have models or DS API integration.
+ * We use the incoming Mobile Commons Profile to retreive required info for the sender, and post to
+ * it to update it with their email, zip, first name, and a custom field to keep donation count.
+ */
 router.post('/', (req, res) => {
   let incomingMessage = req.body.args;
   if (!incomingMessage) {
@@ -42,7 +57,7 @@ router.post('/', (req, res) => {
   logger.debug(`dcbot incomingMessage:${incomingMessage}`);
 
   const profileFieldName = `profile_${COUNT_FIELD}`;
-  const numDonations = req.body[profileFieldName];
+  const numDonations = req.body[profileFieldName] ? Number(req.body[profileFieldName]) : 0;
 
   if (numDonations >= MAX_DONATIONS_ALLOWED) {
     return sendResponse(res, 200, 'max_donations_reached');

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const express = require('express');
+const router = express.Router(); // eslint-disable-line new-cap
+const helpers = require('../../lib/helpers');
+const logger = app.locals.logger;
+
+/**
+ * Setup.
+ */
+const COUNT_FIELD = process.env.DONORSCHOOSE_DONATION_COUNT_FIELDNAME || 'ss2016_donation_count';
+const MAX_DONATIONS_ALLOWED = (process.env.DONORSCHOOSE_MAX_DONATIONS_ALLOWED || 5);
+
+function sendResponse(res, code, msgType, profileUpdate) {
+  logger.debug(`dcbot sendResponse:${msgType} profileUpdate:${JSON.stringify(profileUpdate)}`);
+
+  // TODO: Refactor to store donorsChooseBot instead of Controller once ready to drecpate.
+  const bot = app.locals.controllers.donorsChooseBot.bot;
+  const property = `msg_${msgType}`;
+  // TODO: Post to Mobile Commons Profile
+
+  return helpers.sendResponse(res, 200, bot[property]);
+}
+
+router.post('/', (req, res) => {
+  let incomingMessage = req.body.args;
+  if (!incomingMessage) {
+    return helpers.sendResponse(res, 422, 'Missing required args.');
+  }
+
+  incomingMessage = helpers.getFirstWord(incomingMessage);
+  logger.debug(`dcbot incomingMessage:${incomingMessage}`);
+
+  const profileFieldName = `profile_${COUNT_FIELD}`;
+  const numDonations = req.body[profileFieldName];
+
+  if (numDonations >= MAX_DONATIONS_ALLOWED) {
+    return sendResponse(res, 200, 'max_donations_reached');
+  }
+
+  // If start param passed, initiate conversation, ignoring incomingMessage.
+  const prompt = req.query.start;
+
+  if (!req.body.profile_postal_code) {
+    if (prompt) {
+      return sendResponse(res, 200, 'ask_zip');
+    }
+    if (!helpers.isValidZip(incomingMessage)) {
+      return sendResponse(res, 200, 'invalid_zip');
+    }
+
+    return sendResponse(res, 200, 'ask_first_name', { postal_code: incomingMessage });
+  }
+
+  if (!req.body.profile_first_name) {
+    if (prompt) {
+      return sendResponse(res, 200, 'ask_first_name');
+    }
+    if (helpers.containsNaughtyWords(incomingMessage) || !helpers.hasLetters(incomingMessage)) {
+      return sendResponse(res, 200, 'invalid_first_name');
+    }
+
+    return sendResponse(res, 200, 'ask_email', { first_name: incomingMessage });
+  }
+
+  if (!req.body.profile_email) {
+    if (prompt) {
+      return sendResponse(res, 200, 'ask_email');
+    }
+    if (!helpers.isValidEmail(incomingMessage)) {
+      return sendResponse(res, 200, 'invalid_email');
+    }
+  }
+
+  // We've made it this far, time to donate.
+  // TODO: When time to post to MC Profile, we'll need to save email if !req.body.profile_email.
+
+  return res.send('hi');
+});
+
+module.exports = router;

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -159,7 +159,7 @@ router.post('/', (req, res) => {
         proposal_url: selectedProposal.url,
         school_name: selectedProposal.schoolName,
         school_city: selectedProposal.city,
-        school_state: selectedProposal.state
+        school_state: selectedProposal.state,
       };
 
       return app.locals.db.donorschoose_donations

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -21,6 +21,7 @@ router.use((req, res, next) => {
 
 router.use('/v1/campaigns', require('./campaigns'));
 router.use('/v1/chatbot', require('./chatbot'));
+router.use('/v1/donorschoosebot', require('./donorschoosebot'));
 router.use('/v1/signups', require('./signups'));
 
 // Legacy.

--- a/lib/donorschoose.js
+++ b/lib/donorschoose.js
@@ -1,14 +1,14 @@
-"use strict"
+'use strict';
 
 /**
  * Helper methods to interface with the DonorsChoose API.
  * @see https://data.donorschoose.org/docs/project-listing/json-requests/
  */
-var Entities = require('html-entities').AllHtmlEntities;
-var proposalsHost = 'https://api.donorschoose.org/';
-var donationsHost = 'https://apisecure.donorschoose.org/';
+const Entities = require('html-entities').AllHtmlEntities;
+let proposalsHost = 'https://api.donorschoose.org/';
+let donationsHost = 'https://apisecure.donorschoose.org/';
 
-if (process.env.NODE_ENV != 'production') {
+if (process.env.NODE_ENV !== 'production') {
   proposalsHost = 'https://qa.donorschoose.org/';
   donationsHost = 'https://apiqasecure.donorschoose.org/';
 }
@@ -18,8 +18,9 @@ if (process.env.NODE_ENV != 'production') {
  * @param {object} proposal
  * @return {object}
  */
-module.exports.decodeProposal = function(proposal) {
-  var entities = new Entities();
+module.exports.decodeProposal = function (proposal) {
+  const entities = new Entities();
+
   return {
     id: proposal.id,
     fulfillmentTrailer: entities.decode(proposal.fulfillmentTrailer),
@@ -27,17 +28,17 @@ module.exports.decodeProposal = function(proposal) {
     state: entities.decode(proposal.state),
     schoolName: entities.decode(proposal.schoolName),
     teacherName: entities.decode(proposal.teacherName),
-    url: proposal.proposalURL
+    url: proposal.proposalURL,
   };
-}
+};
 
 /**
  * Returns DonorsChoose API url to post Donations to.
  * @return {string}
  */
-module.exports.getDonationsPostUrl = function() {
-  return donationsHost + 'common/json_api.html';
-}
+module.exports.getDonationsPostUrl = function () {
+  return `${donationsHost}common/json_api.html`;
+};
 
 /**
  * Returns DonorsChoose API url to query for first Project found by given zip.
@@ -46,16 +47,14 @@ module.exports.getDonationsPostUrl = function() {
  * @param {integer} olderThan
  * @return {string}
  */
-module.exports.getProposalsQueryUrl = function(zip, minCostToComplete, olderThan) {
-  var url = proposalsHost + 'common/json_feed.html';
-  // Currently hardcoded for STEM.
-  url += '?subject4=-4'; 
-  url += '&sortBy=2'; 
-  url += '&costToCompleteRange=' + minCostToComplete + '+TO+10000'; 
-  url += '&max=1';
-  url += '&zip=' + zip;
+module.exports.getProposalsQueryUrl = function (zip, minCostToComplete, olderThan) {
+  let url = `${proposalsHost}common/json_feed.html`;
+  // Subject hardcoded for STEM.
+  url = `${url}?subject4=-4&sortBy=2&max=1&zip=${zip}`;
+  url = `${url}&costToCompleteRange=${minCostToComplete}+TO+10000`;
   if (olderThan) {
-    url += '&olderThan=' + olderThan;
+    url = `${url}&olderThan=${olderThan}`;
   }
+
   return url;
-}
+};

--- a/lib/donorschoose.js
+++ b/lib/donorschoose.js
@@ -1,10 +1,12 @@
 'use strict';
 
 /**
- * Helper methods to interface with the DonorsChoose API.
- * @see https://data.donorschoose.org/docs/project-listing/json-requests/
+ * Imports.
  */
+const superagent = require('superagent');
 const Entities = require('html-entities').AllHtmlEntities;
+const logger = app.locals.logger;
+
 let proposalsHost = 'https://api.donorschoose.org/';
 let donationsHost = 'https://apisecure.donorschoose.org/';
 
@@ -12,6 +14,29 @@ if (process.env.NODE_ENV !== 'production') {
   proposalsHost = 'https://qa.donorschoose.org/';
   donationsHost = 'https://apiqasecure.donorschoose.org/';
 }
+
+function parseResponse(response) {
+  if (!response.text) {
+    throw new Error('Cannot parse DonorsChoose API get response.');
+  }
+
+  return JSON.parse(response.text);
+}
+
+/**
+ * Helper function to execute GET post.
+ */
+module.exports.get = function (uri, query) {
+  console.log(`get:${uri} query:${JSON.stringify(query)}`);
+
+  return superagent
+    .get(uri)
+    .query(query)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .then(response => parseResponse(response))
+    .catch(err => logger.error(err.message));
+};
 
 /**
  * Decodes proposal response object returned from DonorsChoose API.
@@ -21,7 +46,7 @@ if (process.env.NODE_ENV !== 'production') {
 module.exports.decodeProposal = function (proposal) {
   const entities = new Entities();
 
-  return {
+  const data = {
     id: proposal.id,
     fulfillmentTrailer: entities.decode(proposal.fulfillmentTrailer),
     city: entities.decode(proposal.city),
@@ -30,6 +55,8 @@ module.exports.decodeProposal = function (proposal) {
     teacherName: entities.decode(proposal.teacherName),
     url: proposal.proposalURL,
   };
+
+  return data;
 };
 
 /**

--- a/lib/donorschoose.js
+++ b/lib/donorschoose.js
@@ -7,6 +7,7 @@ const superagent = require('superagent');
 const Entities = require('html-entities').AllHtmlEntities;
 const logger = app.locals.logger;
 
+// TODO: Refactor as env variables:
 let proposalsHost = 'https://api.donorschoose.org/';
 let donationsHost = 'https://apisecure.donorschoose.org/';
 
@@ -15,6 +16,9 @@ if (process.env.NODE_ENV !== 'production') {
   donationsHost = 'https://apiqasecure.donorschoose.org/';
 }
 
+/**
+ * Helper function to parse a DonorsChoose API response.
+ */
 function parseResponse(response) {
   if (!response.text) {
     throw new Error('Cannot parse DonorsChoose API get response.');
@@ -24,16 +28,31 @@ function parseResponse(response) {
 }
 
 /**
- * Helper function to execute GET post.
+ * Helper function to execute GET request to given DonorsChoose API uri with given query.
  */
 module.exports.get = function (uri, query) {
-  console.log(`get:${uri} query:${JSON.stringify(query)}`);
+  logger.debug(`donorschoose.get:${uri} query:${JSON.stringify(query)}`);
 
   return superagent
     .get(uri)
     .query(query)
     .set('Accept', 'application/json')
     .set('Content-Type', 'application/json')
+    .then(response => parseResponse(response))
+    .catch(err => logger.error(err.message));
+};
+
+/**
+ * Helper function to execute POST request to given DonorsChoose API uri with given data.
+ */
+module.exports.post = function (uri, data) {
+  logger.debug(`donorschoose.post:${uri} data:${JSON.stringify(data)}`);
+
+  return superagent.post(uri)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .type('form')
+    .send(data)
     .then(response => parseResponse(response))
     .catch(err => logger.error(err.message));
 };
@@ -58,6 +77,8 @@ module.exports.decodeProposal = function (proposal) {
 
   return data;
 };
+
+// TODO: Remove code below once /v1/donorschoosebot endpoint is live.
 
 /**
  * Returns DonorsChoose API url to post Donations to.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Imports.
  */
@@ -209,4 +211,17 @@ module.exports.generatePassword = function(text) {
     .update(text)
     .digest('hex')
     .substring(0,6);
+}
+
+module.exports.sendResponse = function(res, code, message) {
+  let type = 'success';
+  if (code > 200) {
+    type = 'error';
+    logger.error(message);
+  }
+
+  const response = {};
+  response[type] = { code, message };
+
+  return res.status(code).send(response);
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint",
     "start": "node server",
-    "lint": "eslint --ext=.js server.js app/routes app/exceptions app/models app/controllers/CampaignBotController.js lib/gambit-junior.js lib/groups.js"
+    "lint": "eslint --ext=.js server.js app/routes app/exceptions app/models app/controllers/CampaignBotController.js lib/gambit-junior.js lib/donorschoose.js lib/groups.js"
   },
   "eslintConfig": {
     "globals": {

--- a/server.js
+++ b/server.js
@@ -150,9 +150,11 @@ conn.on('connected', () => {
     })
     .catch(err => logger.error(err));
 
-  const donorsChooseBotID = process.env.DONORSCHOOSEBOT_ID || 31;
-  const loadDonorsChooseBot = loader.loadBot('donorschoosebot', donorsChooseBotID)
+  const donorsChooseBotId = process.env.DONORSCHOOSEBOT_ID || 31;
+  const loadDonorsChooseBot = loader.loadBot('donorschoosebot', donorsChooseBotId)
     .then((bot) => {
+      app.locals.donorsChooseBot = bot;
+      // TODO: Deprecate DonorsChooseBotController entirely once donorschoosebot endpoint is live.
       const DonorsChooseBotController = rootRequire('app/controllers/DonorsChooseBotController');
       app.locals.controllers.donorsChooseBot = new DonorsChooseBotController(bot);
       logger.info('loaded app.locals.controllers.donorsChooseBot');


### PR DESCRIPTION
#### What's this PR do?
Begins a `/v1/donorschoosebot` endpoint to eventually deprecate use of `/v1/chatbot?bot_type=donorschoosebot`. This endpoint will post a donation if all the expected Mobile Commons Profile fields are passed in the `req.body`, but doesn't save anything to the user's  Mobile Commons Profile. Opening this now to help keep the pull request reviewable.

* Adds new `app/routes/donorschoosebot` to handle logic of inspecting Mobile Commons Profile, sent message from User, and determining how to respond.
    * Uses promises to avoid callback hell (similar to CampaignBot makeover in #632)

* Adds `lib/donorschoose.js` for lint -- adds helper `superagent` functions for DonorsChoose API requests

* Adds `DONORSCHOOSE_API_BASEURI` and `DONORSCHOOSE_API_SECURE_BASEURI` to avoid hardcoding URL's for use with new route


#### How should this be reviewed?
Post to `/v1/donorschoosebot` locally with expected params defined in [chatbot docs](https://github.com/DoSomething/gambit/blob/develop/documentation/endpoints/chatbot.md), if verify ask/invalid messages are sent, and a donation is created if all fields are passed.

#### Any background context you want to provide?

The only time we post to DonorsChooseBot is when a user has completed a SMS Game, so it makes sense to move it out of our `chatbot` endpoint entirely and into its own `donorschoosebot` endpoint.

Next steps:
* [ ] Save data to Mobile Commons Profile and deliver messages
* [ ] Update documentation
* [ ] Once live, remove the `DonorsChooseBotController`. Our `package.json` can simply lint our entire `app` directory instead of specifying each subdirectory

#### Relevant tickets
#584 

#### Checklist
- [x] Tested on staging.
