### PR TITLE
Finish DonorsChooseBot refactor

### DIFF
--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -54,7 +54,7 @@ donorsChooseBotSchema.statics.lookupByID = function (id) {
 };
 
 /**
- * Returns rendered DonorsChooseBot message for given Express req and given msgType
+ * Returns rendered DonorsChooseBot message for given Express req and given DonorsChooseBot msgType.
  */
 donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
   const property = `msg_${msgType}`;
@@ -67,7 +67,6 @@ donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
     msg = msg.replace('{{description}}', req.donation.proposal_description);
     msg = msg.replace('{{school_name}}', req.donation.school_name);
     msg = msg.replace('{{teacher_name}}', req.donation.teacher_name);
-    // TODO: Use bitly if production.
     msg = msg.replace('{{url}}', req.donation.proposal_url);
   }
 

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -53,6 +53,27 @@ donorsChooseBotSchema.statics.lookupByID = function (id) {
   });
 };
 
+/**
+ * Returns rendered DonorsChooseBot message for given Express req and given msgType
+ */
+donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
+  const property = `msg_${msgType}`;
+  let msg = this[property];
+
+  if (req.body.profile_postal_code) {
+    msg = msg.replace('{{postal_code}}', req.body.profile_postal_code);
+  }
+  if (req.donation) {
+    msg = msg.replace('{{description}}', req.donation.proposal_description);
+    msg = msg.replace('{{school_name}}', req.donation.school_name);
+    msg = msg.replace('{{teacher_name}}', req.donation.teacher_name);
+    // TODO: Use bitly if production.
+    msg = msg.replace('{{url}}', req.donation.proposal_url);
+  }
+
+  return msg;
+};
+
 module.exports = function (connection) {
   return connection.model('donorschoosebots', donorsChooseBotSchema);
 };

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -14,6 +14,7 @@ const donorsChooseBotSchema = new mongoose.Schema({
   msg_ask_email: String,
   msg_ask_first_name: String,
   msg_ask_zip: String,
+  msg_donation_confirmation: String,
   msg_donation_success: String,
   msg_error_generic: String,
   msg_invalid_email: String,

--- a/app/models/DonorsChooseDonation.js
+++ b/app/models/DonorsChooseDonation.js
@@ -9,9 +9,6 @@ const schema = new mongoose.Schema({
 
   created_at: { type: Date, default: Date.now },
 
-  mobilecommons_campaign_id: Number,
-  donorschoosebot_id: Number,
-
   // Member profile our donation is on behalf of.
   mobile: { type: String, index: true },
   profile_email: String,
@@ -27,6 +24,8 @@ const schema = new mongoose.Schema({
   school_name: String,
   school_city: String,
   school_state: String,
+  teacher_name: String,
+  proposal_description: String,
 
 });
 

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -216,8 +216,9 @@ router.post('/', (req, res) => {
     })
     .then((donation) => {
       logger.debug(`stored donorschoose_donation:${donation.donation_id}`);
+      scope.donation = donation;
 
-      return res.send(donation);
+      return sendResponse(scope, res, 200, 'donation_confirmation');
     })
     .catch(err => res.status(500).send(err.message));
 });

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -28,7 +28,11 @@ function info(req, message) {
 function sendResponse(req, res, code, msgType) {
   debug(req, `sendResponse:${msgType}`);
   const scope = req;
-  const responseMessage = app.locals.donorsChooseBot.renderMessage(req, msgType);
+  let responseMessage = app.locals.donorsChooseBot.renderMessage(req, msgType);
+  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
+  if (senderPrefix) {
+    responseMessage = `${senderPrefix} ${responseMessage}`;
+  }
 
   scope.profile_update.gambit_chatbot_response = responseMessage;
   mobilecommons.profile_update(req.body.phone, scope.oip, scope.profile_update);

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -124,7 +124,9 @@ router.post('/', (req, res) => {
       return sendResponse(scope, res, 200, 'invalid_email');
     }
 
-    scope.profile_update.profile_email = incomingMessage;
+    const email = incomingMessage.toLowerCase();
+    scope.profile_update.profile_email = email;
+    scope.body.profile_email = email;
   }
 
   // We've got all required profile fields -- time to donate.
@@ -188,7 +190,7 @@ router.post('/', (req, res) => {
         proposalId: selectedProposal.id,
         amount: donationAmount,
         email: donorEmail,
-        honoreeEmail: req.body.profile_email,
+        honoreeEmail: scope.body.profile_email,
         honoreeFirst: req.body.profile_first_name,
       };
 
@@ -199,7 +201,7 @@ router.post('/', (req, res) => {
 
       const data = {
         mobile: req.body.phone,
-        profile_email: req.body.profile_email,
+        profile_email: scope.body.profile_email,
         profile_first_name: req.body.profile_first_name,
         profile_postal_code: zip,
         donation_id: donation.donationId,

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -135,7 +135,8 @@ router.post('/', (req, res) => {
     }
 
     const email = incomingMessage.toLowerCase();
-    scope.profile_update.profile_email = email;
+    scope.profile_update.email = email;
+    // Save to body for later when we create a Donation document.
     scope.body.profile_email = email;
   }
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,7 +5,14 @@
 
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`POST /v1/chatbot` | [Chat](endpoints/chatbot.md#chat)
+`POST /v1/chatbot` | [CampaignBot chat](endpoints/chatbot.md)
+
+
+## DonorsChooseBot
+
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /v1/donorschoosebot` | [DonorsChooseBot chat](endpoints/donorschoosebot.md)
 
 
 ## Campaigns
@@ -29,6 +36,4 @@ Endpoint                                       | Functionality
 
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------
-`POST /ds-routing/campaign-transition` | [Mobile Commons campaign transition](https://github.com/DoSomething/gambit/wiki/API#moco-campaign-transition)
-`POST /ds-routing/yes-no-gateway` | [Submit yes or no](https://github.com/DoSomething/gambit/wiki/API#yes-no)
 `POST /reportback/:campaignName` | [Reportback chat](https://github.com/DoSomething/gambit/wiki/API#reportback)

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -16,9 +16,8 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`broadcast` | `boolean` | For use with `campaignbot` -- if set, parses User's sent message as either Yes or No response to Signup for whatever the `CAMPAIGNBOT_BROADCAST_CAMPAIGN` config var is set to.
-`bot_type` | `string` | Defaults to `campaignbot`, accepts `donorschoosebot`
-`start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
+`broadcast` | `boolean` | If set, inspects User's sent message as either Yes or No response to Signup for whatever the `CAMPAIGNBOT_BROADCAST_CAMPAIGN` config var is set to.
+
 
 **Input**
 
@@ -50,7 +49,7 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
 {
   "success": {
     "code": 200,
-    "message": "@thor: Picking up where you left off on Bumble Bands...\n\nNice! Send your best pic of you and the 33 bumble bands you created."
+    "message": "Picking up where you left off on Bumble Bands...\n\nSend your best pic of you and the 33 bumble bands you created."
   }
 }
 ````

--- a/documentation/endpoints/donorschoosebot.md
+++ b/documentation/endpoints/donorschoosebot.md
@@ -1,9 +1,9 @@
-# Chatbot
+# DonorsChooseBot
 
 Currently only implemented for use by a Mobile Commons mData POST request.
 
 ```
-POST /v1/chatbot
+POST /v1/donorschoosebot
 ```
 
 **Headers**
@@ -16,9 +16,7 @@ Name | Type | Description
 
 Name | Type | Description
 --- | --- | ---
-`broadcast` | `boolean` | For use with `campaignbot` -- if set, parses User's sent message as either Yes or No response to Signup for whatever the `CAMPAIGNBOT_BROADCAST_CAMPAIGN` config var is set to.
-`bot_type` | `string` | Defaults to `campaignbot`, accepts `donorschoosebot`
-`start` | `boolean` | If set, the bot will begin a new DonorsChoose conversation if `bot_type=donorschoose`. Default: `false`
+`start` | `boolean` | If set, DonorsChooseBot will initiate conversation and send first message to User.
 
 **Input**
 
@@ -28,18 +26,19 @@ Name | Type | Description
 --- | --- | ---
 `phone` | `string` | **Required.** Mobile number that sent incoming message.
 `args` | `string` | Incoming text sent.
-`mms_image_url` | `string` | Incoming image sent.
-`keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that triggered the incoming mData POST.
 `profile_id` | `number` | Mobile Commons Profile ID
+`profile_first_name` | `string` | Mobile Commons Profile first name
+`profile_email` | `string` | Mobile Commons Profile email
+`profile_postal_code` | `string` | Mobile Commons Profile zip
+`profile_ss2016_donation_count` | `string` | Mobile Commons Custom Field to store number of donations. This parameter name can be changed via `DONORSCHOOSE_DONATION_FIELDNAME`
 
 <details>
 <summary>**Example Request**</summary>
 ````
-curl -X "POST" "http://localhost:5000/v1/chatbot" \
+curl -X "POST" "http://localhost:5000/v1/donorschoosebot?start=true" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
      --data-urlencode "phone=5555555511" \
-     --data-urlencode "keyword=slothieboi"
      --data-urlencode "profile_id=136122001" \
 ````
 </details>
@@ -50,8 +49,9 @@ curl -X "POST" "http://localhost:5000/v1/chatbot" \
 {
   "success": {
     "code": 200,
-    "message": "@thor: Picking up where you left off on Bumble Bands...\n\nNice! Send your best pic of you and the 33 bumble bands you created."
+    "message": "First, text back your zip code to find a project near you to support."
   }
 }
+
 ````
 </details>

--- a/lib/donorschoose.js
+++ b/lib/donorschoose.js
@@ -31,7 +31,7 @@ function parseResponse(response) {
  * Helper function to execute GET request to given DonorsChoose API uri with given query.
  */
 module.exports.get = function (uri, query) {
-  logger.debug(`donorschoose.get:${uri} query:${JSON.stringify(query)}`);
+  logger.debug('donorschoose.get');
 
   return superagent
     .get(uri)
@@ -46,7 +46,7 @@ module.exports.get = function (uri, query) {
  * Helper function to execute POST request to given DonorsChoose API uri with given data.
  */
 module.exports.post = function (uri, data) {
-  logger.debug(`donorschoose.post:${uri} data:${JSON.stringify(data)}`);
+  logger.debug('donorschoose.post');
 
   return superagent.post(uri)
     .set('Accept', 'application/json')

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -219,6 +219,8 @@ exports.optout = function(args) {
 };
 
 /**
+ * TODO: Remove this function once donorschoosebot endpoint is live.
+ *
  * Posts to a chatbot optInPath to send msgTxt to given member.
  * @param {object} member
  * @param {number} optInPath - Id of Opt-in path, needs to contain


### PR DESCRIPTION
#### What's this PR do?
* Adds Mobile Commons integration to `/v1/donorschoosebot` endpoint:
    * Saves first name, email, zip, and donation count to Mobile Commons Profile in `profile_update` POST

* Adds new `msg_donation_confirmation` DonorsChooseBot property to deliver after successful donation
   * Adds Liquid support for Donation `{{school_name}}`, `{{teacher_name}}`, `{{url}}`, `{{description}}`
    * Changed DonorsChooseBot OIP's in Mobile Commons to Force MMS to send single success message

#### How should this be reviewed?
Text in staging DonorsChooseBot keyword upon deploy to staging.

#### Any background context you want to provide?
Once this is deployed to production:
* [ ] Point production DonorsChooseBot mData's to new `donorschoosebot` endpoint instead of `chatbot?bot_type=donorschoosebot`
* [ ] Remove all deprecated code (e.g. `DonorsChooseBotController`) listed in #648 

#### Relevant tickets
#648 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Add new `DONORSCHOOSE_API_BASEURI` and `DONORSCHOOSE_API_SECURE_BASEURI` to staging
- [x] Tested on staging.
- [x] Add new `DONORSCHOOSE_API_BASEURI` and `DONORSCHOOSE_API_SECURE_BASEURI` to prod