### PR TITLE
Refactor CampaignBotController functions as CampaignBot and Signup methods

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -119,23 +119,13 @@ class CampaignBotController {
    */
   createReportbackSubmission(req) {
     this.debug(req, 'createReportbackSubmission');
-    const scope = req;
 
-    return app.locals.db.reportback_submissions
-      .create({
-        campaign: req.campaign._id,
-        user: req.user._id,
-      })
-      .then(reportbackSubmission => {
-        this.debug(scope, `created reportbackSubmission:${reportbackSubmission._id.toString()}`);
-        scope.signup.draft_reportback_submission = reportbackSubmission._id;
-
-        return scope.signup.save();
-      })
+    return req.signup
+      .createDraftReportbackSubmission()
       .then(() => {
-        this.debug(scope, `updated signup:${scope.signup._id.toString()}`);
+        this.debug(req, `updated signup:${req.signup._id.toString()}`);
 
-        return this.collectReportbackProperty(scope, 'quantity', true);
+        return this.collectReportbackProperty(req, 'quantity', true);
       });
   }
 

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -54,6 +54,81 @@ campaignBotSchema.statics.lookupByID = function (id) {
   });
 };
 
+/**
+ * Returns rendered CampaignBot message for given Express req and msgType.
+ * @param {object} req - Express request
+ * @param {string} msgType - Type of bot message to send back
+ * @param {string} prefix - If set, prepended to the bot message text
+ * @return {string} - CampaignBot message with Liquid tags replaced with req properties
+ */
+campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
+  logger.debug(`renderMessage:${msgType}`);
+
+  const botProperty = `msg_${msgType}`;
+  let msg = this[botProperty];
+  const campaign = req.campaign;
+  if (!campaign) {
+    logger.error('renderMessage req.campaign undefined');
+
+    return msg;
+  }
+
+  // Check if campaign has an override defined.
+  if (campaign[botProperty]) {
+    msg = campaign[botProperty];
+  }
+
+  if (!msg) {
+    return this.error(req, 'bot msgType not found');
+  }
+
+  if (prefix) {
+    msg = `${prefix}${msg}`;
+  }
+
+  msg = msg.replace(/{{br}}/gi, '\n');
+  msg = msg.replace(/{{title}}/gi, campaign.title);
+  msg = msg.replace(/{{tagline}}/i, campaign.tagline);
+  msg = msg.replace(/{{fact_problem}}/gi, campaign.fact_problem);
+  msg = msg.replace(/{{rb_noun}}/gi, campaign.rb_noun);
+  msg = msg.replace(/{{rb_verb}}/gi, campaign.rb_verb);
+  msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.msg_rb_confirmation);
+  msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
+  msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+
+  if (campaign.keywords.length) {
+    // Campaign could have multiple keywords, use the first by default.
+    let keyword = campaign.keywords[0].toUpperCase();
+    // If User signed up via keyword, use the keyword they used (vs the first defined above).
+    if (req.signup && req.signup.keyword) {
+      keyword = req.signup.keyword.toUpperCase();
+    }
+    msg = msg.replace(/{{keyword}}/i, keyword);
+  }
+
+  if (req.signup) {
+    let quantity = req.signup.total_quantity_submitted;
+    if (req.signup.draft_reportback_submission) {
+      quantity = req.signup.draft_reportback_submission.quantity;
+    }
+    msg = msg.replace(/{{quantity}}/gi, quantity);
+  }
+
+  const revisiting = req.keyword && req.signup && req.signup.draft_reportback_submission;
+  if (revisiting) {
+    // TODO: New bot property for continue draft message
+    const continueMsg = 'Picking up where you left off on';
+    msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;
+  }
+
+  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
+  if (senderPrefix) {
+    msg = `${senderPrefix} ${msg}`;
+  }
+
+  return msg;
+};
+
 module.exports = function (connection) {
   return connection.model('campaignbots', campaignBotSchema);
 };

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -95,7 +95,7 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
   const model = this;
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Signup.lookupCurrentForUserAndCampaign:${user._id}, ${campaign._id}`);
+    logger.debug(`Signup.lookupCurrent(${user._id}, ${campaign._id})`);
 
     return app.locals.clients.northstar
       .Signups.index({ user: user._id, campaigns: campaign._id })
@@ -151,6 +151,32 @@ signupSchema.statics.post = function (user, campaign, keyword) {
           .then(signup => resolve(signup))
           .catch(error => reject(error));
       })
+      .catch(err => reject(err));
+  });
+};
+
+/**
+ * Creates a new Reportback Submission model and saves it to Signup's draft_reportback_submission.
+ */
+signupSchema.methods.createDraftReportbackSubmission = function () {
+  const signup = this;
+
+  return new Promise((resolve, reject) => {
+    logger.debug('Signup.createDraftReportbackSubmission');
+
+    return app.locals.db.reportback_submissions
+      .create({
+        campaign: signup.campaign,
+        user: signup.user,
+      })
+      .then(reportbackSubmission => {
+        const submissionId = reportbackSubmission._id;
+        logger.debug(`Signup.createDraftReportbackSubmission created:${submissionId.toString()}`);
+        signup.draft_reportback_submission = submissionId;
+
+        return signup.save();
+      })
+      .then(updatedSignup => resolve(updatedSignup))
       .catch(err => reject(err));
   });
 };

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -18,6 +18,8 @@ const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError
  */
 router.post('/', (req, res) => {
   const controller = app.locals.controllers.campaignBot;
+  const campaignBot = app.locals.campaignBot;
+
   const scope = req;
   scope.oip = process.env.MOBILECOMMONS_OIP_CHATBOT;
   scope.incoming_message = req.body.args;
@@ -176,7 +178,7 @@ router.post('/', (req, res) => {
       if (controller.isCommand(scope, 'member_support')) {
         scope.cmd_member_support = true;
         scope.oip = agentViewOip;
-        return controller.renderResponseMessage(scope, 'member_support');
+        return campaignBot.renderMessage(scope, 'member_support');
       }
 
       if (scope.signup.draft_reportback_submission) {
@@ -190,17 +192,17 @@ router.post('/', (req, res) => {
 
       if (scope.signup.reportback) {
         if (scope.keyword || req.query.broadcast) {
-          return controller.renderResponseMessage(scope, 'menu_completed');
+          return campaignBot.renderMessage(scope, 'menu_completed');
         }
         // If we're this far, member didn't text back Reportback or Member Support commands.
-        return controller.renderResponseMessage(scope, 'invalid_cmd_completed');
+        return campaignBot.renderMessage(scope, 'invalid_cmd_completed');
       }
 
       if (scope.keyword || req.query.broadcast) {
-        return controller.renderResponseMessage(scope, 'menu_signedup_gambit');
+        return campaignBot.renderMessage(scope, 'menu_signedup_gambit');
       }
 
-      return controller.renderResponseMessage(scope, 'invalid_cmd_signedup');
+      return campaignBot.renderMessage(scope, 'invalid_cmd_signedup');
     })
     .then((msg) => {
       scope.response_message = msg;
@@ -225,7 +227,7 @@ router.post('/', (req, res) => {
       // TODO: Send StatHat report to inform staff CampaignBot is running a closed Campaign.
       // We don't want to send an error back as response, but instead deliver success to Mobile
       // Commons and deliver the Campaign Closed message back to our User.
-      const msg = controller.renderResponseMessage(scope, 'campaign_closed');
+      const msg = campaignBot.renderMessage(scope, 'campaign_closed');
       // Send to Agent View for now until we get a Select Campaign menu up and running.
       scope.user.postMobileCommonsProfileUpdate(agentViewOip, msg);
 
@@ -234,7 +236,7 @@ router.post('/', (req, res) => {
     })
     .catch(err => {
       if (err.message === 'broadcast declined') {
-        const msg = controller.renderResponseMessage(scope, 'signup_broadcast_declined');
+        const msg = campaignBot.renderMessage(scope, 'signup_broadcast_declined');
         scope.user.postMobileCommonsProfileUpdate(agentViewOip, msg);
 
         return helpers.sendResponse(res, 200, msg);

--- a/lib/junior.js
+++ b/lib/junior.js
@@ -55,7 +55,8 @@ function parseIndex(response, endpoint) {
 module.exports.get = function (endpoint, id) {
   return superagent
     .get(`${uri}/${endpoint}/${id}`)
-    .then(response => parseGet(response, endpoint));
+    .then(response => parseGet(response, endpoint))
+    .catch(err => logger.error(err.message));
 };
 
 /**
@@ -64,5 +65,6 @@ module.exports.get = function (endpoint, id) {
 module.exports.index = function (endpoint) {
   return superagent
     .get(`${uri}/${endpoint}`)
-    .then(response => parseIndex(response, endpoint));
+    .then(response => parseIndex(response, endpoint))
+    .catch(err => logger.error(err.message));
 };

--- a/server.js
+++ b/server.js
@@ -142,6 +142,7 @@ conn.on('connected', () => {
   const campaignBotID = process.env.CAMPAIGNBOT_ID || 41;
   const loadCampaignBot = loader.loadBot('campaignbot', campaignBotID)
     .then((bot) => {
+      app.locals.campaignBot = bot;
       const CampaignBotController = rootRequire('app/controllers/CampaignBotController');
       app.locals.controllers.campaignBot = new CampaignBotController(bot);
       logger.info('loaded app.locals.controllers.campaignBot');

--- a/server.js
+++ b/server.js
@@ -139,8 +139,8 @@ conn.on('connected', () => {
    */
   app.locals.controllers = {};
 
-  const campaignBotID = process.env.CAMPAIGNBOT_ID || 41;
-  const loadCampaignBot = loader.loadBot('campaignbot', campaignBotID)
+  const campaignBotId = process.env.CAMPAIGNBOT_ID || 41;
+  const loadCampaignBot = loader.loadBot('campaignbot', campaignBotId)
     .then((bot) => {
       app.locals.campaignBot = bot;
       const CampaignBotController = rootRequire('app/controllers/CampaignBotController');
@@ -149,7 +149,7 @@ conn.on('connected', () => {
 
       return app.locals.controllers.campaignBot;
     })
-    .catch(err => logger.error(err));
+    .catch(err => logger.error(err.message));
 
   const donorsChooseBotId = process.env.DONORSCHOOSEBOT_ID || 31;
   const loadDonorsChooseBot = loader.loadBot('donorschoosebot', donorsChooseBotId)
@@ -161,7 +161,8 @@ conn.on('connected', () => {
       logger.info('loaded app.locals.controllers.donorsChooseBot');
 
       return app.locals.controllers.donorsChooseBot;
-    });
+    })
+    .catch(err => logger.error(err.message));
 
   /**
    * Load legacy configs.
@@ -195,7 +196,7 @@ conn.on('connected', () => {
       });
     })
     .catch((err) => {
-      logger.error(err);
+      logger.error(err.message);
       process.exit(1);
     });
 });


### PR DESCRIPTION
#### What's this PR do?
Some CampaignBot cleanup -- end goal here is to deprecate `CampaignBotController` completely in favor of handling all conversation logic in `app/routes/chatbot`, and define all get/post methods  in the relevant `app/models` classes. This PR gets us pretty close, mostly just by copy/pasting code from one class to another.

* Refactor `CampaignBotController.renderResponseMessage` as `CampaignBot.renderMessage`, keeping consistent with changes to `DonorsChooseBot` in #722 
* Adds `Signup` instance methods to create a draft Reportback Submission for the Signup, or to post the Signup's draft Reportback Submission to DS API (and update Signup accordingly upon success or fail) 

#### How should this be reviewed?
Test full CampaignBot conversations to verify all networking calls work as expected.

#### Any background context you want to provide?
* Last big functions to move out of `CampaignBotController` and into `app/routes/chatbot` (and possibly `ReportbackSubmission`) are determining what Reportback Submission property to ask for, or to validate and save.
* Ideally, refactor `return` statements to just return the message type to render (to DRY returning `campaignBot.renderMessage`)

#### Checklist
- [ ] Tested on staging.

