### PR TITLE
Adds StatHat events for routes, users, signups, reportbacks, donations, bot messages

### DIFF
--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -7,6 +7,7 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const gambitJunior = rootRequire('lib/junior');
 const logger = app.locals.logger;
+const stathat = app.locals.stathat;
 
 const campaignBotSchema = new mongoose.Schema({
 
@@ -62,7 +63,9 @@ campaignBotSchema.statics.lookupByID = function (id) {
  * @return {string} - CampaignBot message with Liquid tags replaced with req properties
  */
 campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
-  logger.debug(`renderMessage:${msgType}`);
+  const logMsg = `campaignbot: ${msgType}`;
+  logger.info(logMsg);
+  stathat(logMsg);
 
   const botProperty = `msg_${msgType}`;
   let msg = this[botProperty];

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -7,6 +7,7 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const gambitJunior = rootRequire('lib/junior');
 const logger = app.locals.logger;
+const stathat = app.locals.stathat;
 
 const donorsChooseBotSchema = new mongoose.Schema({
 
@@ -57,6 +58,10 @@ donorsChooseBotSchema.statics.lookupByID = function (id) {
  * Returns rendered DonorsChooseBot message for given Express req and given DonorsChooseBot msgType.
  */
 donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
+  const logMsg = `donorschoosebot: ${msgType}`;
+  logger.info(logMsg);
+  stathat(logMsg);
+
   const property = `msg_${msgType}`;
   let msg = this[property];
 

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -4,6 +4,8 @@ const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
 
 router.get('/', (req, res) => {
+  app.locals.stathat('route: v1/campaigns');
+
   const findClause = {};
   if (req.query.campaignbot) {
     const campaignConfigVar = process.env.CAMPAIGNBOT_CAMPAIGNS;
@@ -22,6 +24,7 @@ router.get('/', (req, res) => {
 });
 
 router.get('/:id', (req, res) => {
+  app.locals.stathat('route: v1/campaigns/{id}');
   app.locals.logger.debug(`get campaign ${req.params.id}`);
 
   return app.locals.db.campaigns

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -26,6 +26,8 @@ function isCommand(incomingMessage, commandType) {
  * Currently only supports Mobile Commons mData's.
  */
 router.post('/', (req, res) => {
+  app.locals.stathat('route: v1/chatbot');
+
   const controller = app.locals.controllers.campaignBot;
   const campaignBot = app.locals.campaignBot;
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -5,8 +5,8 @@
  */
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
-
 const logger = app.locals.logger;
+const stathat = app.locals.stathat;
 const Promise = require('bluebird');
 const helpers = require('../../lib/helpers');
 const NotFoundError = require('../exceptions/NotFoundError');
@@ -26,7 +26,7 @@ function isCommand(incomingMessage, commandType) {
  * Currently only supports Mobile Commons mData's.
  */
 router.post('/', (req, res) => {
-  app.locals.stathat('route: v1/chatbot');
+  stathat('route: v1/chatbot');
 
   const controller = app.locals.controllers.campaignBot;
   const campaignBot = app.locals.campaignBot;
@@ -59,7 +59,9 @@ router.post('/', (req, res) => {
   ];
   settings.forEach((configVar) => {
     if (!process.env[configVar]) {
-      logger.error(`undefined process.env.${configVar}`);
+      const msg = `undefined process.env.${configVar}`;
+      stathat(`error: ${msg}`);
+      logger.error(msg);
       configured = false;
     }
   });
@@ -69,6 +71,8 @@ router.post('/', (req, res) => {
   }
 
   if (!req.body.phone) {
+    stathat('error: undefined req.body.phone');
+
     return res.status(422).send({ error: 'phone is required.' });
   }
 
@@ -80,7 +84,7 @@ router.post('/', (req, res) => {
       .then(user => resolve(user))
       .catch((err) => {
         if (err && err.status === 404) {
-          logger.debug(`app.locals.db.users.lookup could not find mobile:${req.body.phone}`);
+          logger.info(`app.locals.db.users.lookup could not find mobile:${req.body.phone}`);
 
           const user = app.locals.db.users.post({
             mobile: req.body.phone,
@@ -96,7 +100,7 @@ router.post('/', (req, res) => {
 
   return loadUser
     .then((user) => {
-      logger.debug(`loaded user:${user._id}`);
+      logger.info(`loaded user:${user._id}`);
       scope.user = user;
 
       let campaign;

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -9,6 +9,7 @@ const donorschoose = require('../../lib/donorschoose');
 const mobilecommons = require('../../lib/mobilecommons');
 const helpers = require('../../lib/helpers');
 const logger = app.locals.logger;
+const stathat = app.locals.stathat;
 
 function debug(req, message) {
   logger.debug(`donorschoosebot profile:${req.body.profile_id} ${message}`);
@@ -60,7 +61,7 @@ function sendResponse(req, res, code, msgType) {
  * it to update it with their email, zip, first name, and a custom field to keep donation count.
  */
 router.post('/', (req, res) => {
-  app.locals.stathat('route: v1/donorschoosebot');
+  stathat('route: v1/donorschoosebot');
 
   let incomingMessage = req.body.args;
   const scope = req;
@@ -81,6 +82,7 @@ router.post('/', (req, res) => {
 
   if (numDonations >= maxDonationsAllowed) {
     scope.oip = agentViewOip;
+    stathat('donorschoosebot: max_donations_reached');
 
     return sendResponse(scope, res, 200, 'max_donations_reached');
   }
@@ -190,6 +192,8 @@ router.post('/', (req, res) => {
     .then((tokenResponse) => {
       debug(req, `token.statusDescription:${tokenResponse.statusDescription}`);
       if (tokenResponse.statusDescription !== 'success') {
+        stathat('error: donorschoosebot POST token');
+
         throw new Error('DonorsChoose API request for token failed.');
       }
 
@@ -209,6 +213,7 @@ router.post('/', (req, res) => {
       return donorschoose.post(donationsUri, data);
     })
     .then((donation) => {
+      stathat('donorschoosebot POST donation success');
       info(req, `created donation_id:${donation.donationId}`);
 
       const data = {
@@ -240,11 +245,13 @@ router.post('/', (req, res) => {
     })
     .catch((err) => {
       if (err.message === 'no search results') {
+        stathat('donorschoosebot no projects found');
         scope.oip = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ERROR;
 
         return sendResponse(scope, res, 200, 'search_no_results');
       }
 
+      stathat(`error: donorschoosebot API ${err.message}`);
       error(req, err.message);
 
       return res.status(500).send(err.message);

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -82,7 +82,6 @@ router.post('/', (req, res) => {
 
   if (numDonations >= maxDonationsAllowed) {
     scope.oip = agentViewOip;
-    stathat('donorschoosebot: max_donations_reached');
 
     return sendResponse(scope, res, 200, 'max_donations_reached');
   }
@@ -192,7 +191,7 @@ router.post('/', (req, res) => {
     .then((tokenResponse) => {
       debug(req, `token.statusDescription:${tokenResponse.statusDescription}`);
       if (tokenResponse.statusDescription !== 'success') {
-        stathat('error: donorschoosebot POST token');
+        stathat('donorschoosebot: POST token failed');
 
         throw new Error('DonorsChoose API request for token failed.');
       }
@@ -213,7 +212,7 @@ router.post('/', (req, res) => {
       return donorschoose.post(donationsUri, data);
     })
     .then((donation) => {
-      stathat('donorschoosebot POST donation success');
+      stathat('donorschoosebot: POST donation success');
       info(req, `created donation_id:${donation.donationId}`);
 
       const data = {
@@ -245,13 +244,13 @@ router.post('/', (req, res) => {
     })
     .catch((err) => {
       if (err.message === 'no search results') {
-        stathat('donorschoosebot no projects found');
+        stathat('donorschoosebot: no projects found');
         scope.oip = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ERROR;
 
         return sendResponse(scope, res, 200, 'search_no_results');
       }
 
-      stathat(`error: donorschoosebot API ${err.message}`);
+      stathat(`donorschoosebot: error ${err.message}`);
       error(req, err.message);
 
       return res.status(500).send(err.message);

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -60,8 +60,9 @@ function sendResponse(req, res, code, msgType) {
  * it to update it with their email, zip, first name, and a custom field to keep donation count.
  */
 router.post('/', (req, res) => {
-  let incomingMessage = req.body.args;
+  app.locals.stathat('route: v1/donorschoosebot');
 
+  let incomingMessage = req.body.args;
   const scope = req;
   // Initialize object to store profile data to save when posting Mobile Commons profile_update API.
   scope.profile_update = {};

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,11 @@ const router = express.Router(); // eslint-disable-line new-cap
 
 app.use('/', router);
 
-router.get('/', (req, res) => res.send('hi'));
+router.get('/', (req, res) => {
+  app.locals.stathat('route: /');
+
+  return res.send('hi');
+});
 
 /**
  * Authentication.
@@ -13,7 +17,9 @@ router.get('/', (req, res) => res.send('hi'));
 router.use((req, res, next) => {
   const apiKey = process.env.GAMBIT_API_KEY;
   if (req.method === 'POST' && req.headers['x-gambit-api-key'] !== apiKey) {
+    app.locals.stathat('invalid x-gambit-api-key error');
     app.locals.logger.warn('router invalid x-gambit-api-key:', req.url);
+
     return res.sendStatus(403);
   }
   return next();

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -17,7 +17,7 @@ router.get('/', (req, res) => {
 router.use((req, res, next) => {
   const apiKey = process.env.GAMBIT_API_KEY;
   if (req.method === 'POST' && req.headers['x-gambit-api-key'] !== apiKey) {
-    app.locals.stathat('invalid x-gambit-api-key error');
+    app.locals.stathat('error: invalid x-gambit-api-key');
     app.locals.logger.warn('router invalid x-gambit-api-key:', req.url);
 
     return res.sendStatus(403);

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -20,6 +20,8 @@ function sendResponse(res, code, message) {
 }
 
 router.post('/', (req, res) => {
+  app.locals.stathat('route: v1/signups');
+
   if (!req.body.id) {
     return sendResponse(res, 422, 'Missing required id.');
   }


### PR DESCRIPTION
#### What's this PR do?
* Adds a `app.locals.stathat(statName)` function to wrap calls to the `stathat` library's `trackEZCount` function. Follows Northstar naming convention.

* Tracks requests to Gambit API requests, and success/fail for posts to DoSomething, DonorsChoose APIs

#### How should this be reviewed?
* 👀 Stathat

#### Any background context you want to provide?
More to add:
* [ ] POST Mobile Commons `profile_update` success / fail
* [x] Track bot message types sent (e.g. `msg_invalid_quantity`)
* [ ] Configuration errors

#### Relevant tickets
#714 

#### Checklist
- [x] Tested on staging.
