### PR TITLE
Add Stathat for Mobile Commons, fixes external Signup confirmations

### DIFF
--- a/app/models/User.js
+++ b/app/models/User.js
@@ -9,7 +9,6 @@ const Promise = require('bluebird');
 const helpers = rootRequire('lib/helpers');
 const mobilecommons = rootRequire('lib/mobilecommons');
 const logger = app.locals.logger;
-const stathat = app.locals.stathat;
 
 /**
  * Schema.
@@ -51,15 +50,15 @@ function parseNorthstarUser(northstarUser) {
  */
 userSchema.statics.lookup = function (type, id) {
   const model = this;
-  const statName = 'GET users';
+  const statName = 'northstar: GET users';
 
   return new Promise((resolve, reject) => {
-    logger.debug(`User.lookup type:${type} id:${id}`);
+    logger.debug(`User.lookup(${type}, ${id})`);
 
     return app.locals.clients.northstar.Users
       .get(type, id)
       .then((northstarUser) => {
-        stathat(`${statName} success`);
+        app.locals.stathat(`${statName} 200`);
         logger.debug('northstar.Users.lookup success');
         const data = parseNorthstarUser(northstarUser);
 
@@ -70,11 +69,7 @@ userSchema.statics.lookup = function (type, id) {
           .catch(error => reject(error));
       })
       .catch((error) => {
-        if (error && error.status === 404) {
-          stathat(`${statName} 404`);
-        } else {
-          stathat(`error: ${statName}`);
-        }
+        app.locals.stathatError(statName, error);
 
         return reject(error);
       });
@@ -86,7 +81,7 @@ userSchema.statics.lookup = function (type, id) {
  */
 userSchema.statics.post = function (data) {
   const model = this;
-  const statName = 'POST users';
+  const statName = 'northstar: POST users';
 
   const scope = data;
   scope.source = process.env.DS_API_USER_REGISTRATION_SOURCE || 'sms';
@@ -100,7 +95,7 @@ userSchema.statics.post = function (data) {
     return app.locals.clients.northstar.Users
       .create(scope)
       .then((northstarUser) => {
-        stathat(`${statName} success`);
+        app.locals.stathat(`${statName} 200`);
         logger.info(`northstar.Users created user:${northstarUser.id}`);
 
         return model
@@ -113,7 +108,7 @@ userSchema.statics.post = function (data) {
           .catch(error => reject(error));
       })
       .catch((error) => {
-        stathat(`error: ${statName}`);
+        app.locals.stathatError(statName, error);
 
         return reject(error);
       });

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -20,6 +20,7 @@ const userSchema = new mongoose.Schema({
   // TODO: Not sure we need this index
   mobile: { type: String, index: true },
   phoenix_id: Number,
+  mobilecommons_id: Number,
   email: String,
   role: String,
   first_name: String,
@@ -38,6 +39,7 @@ function parseNorthstarUser(northstarUser) {
     first_name: northstarUser.firstName,
     email: northstarUser.email,
     phoenix_id: northstarUser.drupalID,
+    mobilecommons_id: northstarUser.mobilecommonsID,
     role: northstarUser.role,
   };
 
@@ -120,17 +122,17 @@ userSchema.statics.post = function (data) {
 
 /**
  * Updates MC Profile gambit_chatbot_response Custom Field with given msgTxt to deliver over SMS.
- * @param {number} optInPathID - ID of the Mobile Commons Opt-in Path that will send a message
+ * @param {number} oip - Opt-in Path ID of the Mobile Commons Opt-in Path that will send a message
  * @param {string} msgText - text message content to send to User
  */
-userSchema.methods.postMobileCommonsProfileUpdate = function (optInPathID, msgTxt) {
+userSchema.methods.postMobileCommonsProfileUpdate = function (oip, msgTxt) {
   const data = {
     // The MC Opt-in Path Conversation needs to render gambit_chatbot_response value as Liquid tag.
     // @see https://github.com/DoSomething/gambit/wiki/Chatbot#mobile-commons
     gambit_chatbot_response: msgTxt,
   };
 
-  return mobilecommons.profile_update(this.mobile, optInPathID, data);
+  return mobilecommons.profile_update(this.mobilecommons_id, this.mobile, oip, data);
 };
 
 module.exports = function (connection) {

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -42,7 +42,7 @@ router.post('/', (req, res) => {
     incomingLog = `${incomingLog} keyword:${scope.keyword}`;
   }
 
-  logger.debug(incomingLog);
+  logger.info(incomingLog);
 
   const botType = req.query.bot_type;
   if (botType === 'donorschoose' || botType === 'donorschoosebot') {
@@ -181,7 +181,7 @@ router.post('/', (req, res) => {
       return app.locals.db.signups.post(scope.user, scope.campaign, scope.keyword);
     })
     .then((signup) => {
-      logger.debug(`loaded signup:${signup._id.toString()}`);
+      logger.info(`loaded signup:${signup._id.toString()}`);
       scope.signup = signup;
 
       if (!scope.signup) {

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -40,7 +40,8 @@ function sendResponse(req, res, code, msgType) {
   }
 
   scope.profile_update.gambit_chatbot_response = responseMessage;
-  mobilecommons.profile_update(req.body.phone, scope.oip, scope.profile_update);
+  const profile = req.body;
+  mobilecommons.profile_update(profile.profile_id, profile.phone, scope.oip, scope.profile_update);
 
   return helpers.sendResponse(res, code, responseMessage);
 }

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -192,7 +192,7 @@ router.post('/', (req, res) => {
     .then((tokenResponse) => {
       debug(req, `token.statusDescription:${tokenResponse.statusDescription}`);
       if (tokenResponse.statusDescription !== 'success') {
-        stathat('donorschoosebot: POST token failed');
+        stathat(`donorschoose: POST token ${tokenResponse.statusDescription}`);
 
         throw new Error('DonorsChoose API request for token failed.');
       }
@@ -213,7 +213,7 @@ router.post('/', (req, res) => {
       return donorschoose.post(donationsUri, data);
     })
     .then((donation) => {
-      stathat('donorschoosebot: POST donation success');
+      stathat('donorschoose: POST donation 200');
       info(req, `created donation_id:${donation.donationId}`);
 
       const data = {
@@ -245,13 +245,13 @@ router.post('/', (req, res) => {
     })
     .catch((err) => {
       if (err.message === 'no search results') {
-        stathat('donorschoosebot: no projects found');
+        stathat('donorschoose: no projects found');
         scope.oip = process.env.MOBILECOMMONS_OIP_DONORSCHOOSEBOT_ERROR;
 
         return sendResponse(scope, res, 200, 'search_no_results');
       }
 
-      stathat(`donorschoosebot: error ${err.message}`);
+      stathat(`donorschoose: error ${err.message}`);
       error(req, err.message);
 
       return res.status(500).send(err.message);

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -21,7 +21,7 @@ router.post('/', (req, res) => {
   }
   const source = req.body.source;
 
-  logger.info(`POST signup:${signupId} source:${source}`);
+  logger.info(`signups id:${signupId} source:${source}`);
 
   if (source === process.env.DS_API_POST_SOURCE) {
     const msg = `CampaignBot only sends confirmation when source not equal to ${source}.`;

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -33,28 +33,21 @@ exports.profile_update = function(profileId, phone, oip, updateFields) {
     return;
   }
 
-  const updateTxt = JSON.stringify(updateFields);
-  // Use profileId if available to avoid logging.
-  let identifier = `profile:${profileId}`;
+  // Avoid logging mobile numbers when possible.
+  let identifier;
   if (!profileId) {
     identifier = `phone:${phone}`;
+  } else {
+    identifier = `profile:${profileId}`;
   }
+  const updateTxt = JSON.stringify(updateFields);
   logger.info(`mobilecommons.profile_update ${identifier} oip:${oip} update:${updateTxt}`);
 
-  const data = {
-    auth,
-    form: {
-      phone_number: phone,
-      opt_in_path_id: oip
-    }
-  };
-
-  if (typeof updateFields == 'object') {
-    const fieldNames = Object.keys(updateFields);
-    fieldNames.forEach((fieldName) => {
-      data.form[fieldName] = updateFields[fieldName];
-    });
-  }
+  const data = { auth, form: {} };
+  const fieldNames = Object.keys(updateFields);
+  data.form = fieldNames.map((fieldName) =>  updateFields[fieldName]);
+  data.form.phone_number = phone;
+  data.form.opt_in_path_id = oip;
   
   const requestRetry = new RequestRetry();
   requestRetry.setRetryConditions([400, 408, 500]);

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -1,6 +1,4 @@
-/**
- * Helper methods to interface with the Mobile Commons API.
- */
+'use strict';
 
 const request = require('request-promise-native');
 const RequestRetry = require('node-request-retry');
@@ -36,7 +34,12 @@ exports.profile_update = function(profileId, phone, oip, updateFields) {
   }
 
   const updateTxt = JSON.stringify(updateFields);
-  logger.info(`mobilecommons.profile_update profile:${profileId} oip:${oip} update:${updateTxt}`);
+  // Use profileId if available to avoid logging.
+  let identifier = `profile:${profileId}`;
+  if (!profileId) {
+    identifier = `phone:${phone}`;
+  }
+  logger.info(`mobilecommons.profile_update ${identifier} oip:${oip} update:${updateTxt}`);
 
   const data = {
     auth,

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -36,7 +36,7 @@ exports.profile_update = function(profileId, phone, oip, updateFields) {
   }
 
   const updateTxt = JSON.stringify(updateFields);
-  logger.debug(`mobilecommons.profile_update profile:${profileId} oip:${oip} update:${updateTxt}`);
+  logger.info(`mobilecommons.profile_update profile:${profileId} oip:${oip} update:${updateTxt}`);
 
   const data = {
     auth,

--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -7,6 +7,7 @@ const RequestRetry = require('node-request-retry');
 const helpers = rootRequire('lib/helpers');
 const _ = require('underscore');
 const logger = app.locals.logger;
+const stathat = app.locals.stathat;
 
 // Modifying the default Request library's request object.
 RequestRetry.setDefaults({timeout: 120000});
@@ -18,69 +19,56 @@ const auth = {
 };
 
 /**
-* Mobile Commons profile_update API. Can be used to subscribe the user to an
-* opt-in path.
-*
+* Mobile Commons profile_update API. Can be used to subscribe the user to an opt-in path.
 * @see https://mobilecommons.zendesk.com/hc/en-us/articles/202052534-REST-API#ProfileUpdate
 *
-* @param phone
-*   Phone number of the profile to update.
-* @param optInPathId
-*   Opt-in path to subscribe the user to.
-* @param customFields
-*   Object with MoCo custom profile field names as properties, and values to update the user with.
-*   Note: Field names are case-sensitive.
+* @param {object} profileId - Mobile Commons Profile ID
+* @param {number} phone - Phone to opt in
+* @param {string} oip - Opt-in Path to post to
+* @param {object} updateFields - field values to update on current User's Mobile Commons Profile
 */
-
-exports.profile_update = function(phone, optInPathId, customFields) {
+exports.profile_update = function(profileId, phone, oip, updateFields) {
+  const statName = 'mobilecommons: POST profile_update';
   if (process.env.MOBILECOMMONS_DISABLED) {
     logger.warn('MOBILECOMMONS_DISABLED');
 
     return;
   }
 
-  logger.log('debug', 'mobilecommons.profile_update for mobile:%s oip:%s customFields:%s', phone, optInPathId, JSON.stringify(customFields));
+  const updateTxt = JSON.stringify(updateFields);
+  logger.debug(`mobilecommons.profile_update profile:${profileId} oip:${oip} update:${updateTxt}`);
 
-  var url = 'https://secure.mcommons.com/api/profile_update';
-  var authEmail = process.env.MOBILECOMMONS_AUTH_EMAIL;
-  var authPass = process.env.MOBILECOMMONS_AUTH_PASS;
-
-  var postData = {
-    auth: {
-      user: authEmail,
-      pass: authPass
-    },
-    form:{
+  const data = {
+    auth,
+    form: {
       phone_number: phone,
-      opt_in_path_id: optInPathId
+      opt_in_path_id: oip
     }
   };
 
-  if (typeof customFields == 'object') {
-    var customFieldKeys = Object.keys(customFields);
-    for (var i = 0; i < customFieldKeys.length; i++) {
-      var key = customFieldKeys[i];
-      postData.form[key] = customFields[key];
-    }
+  if (typeof updateFields == 'object') {
+    const fieldNames = Object.keys(updateFields);
+    fieldNames.forEach((fieldName) => {
+      data.form[fieldName] = updateFields[fieldName];
+    });
   }
-
-  var trace = new Error().stack;
-  var callback = function(error, response, body) {
-    if (error) {
-      logger.error('mobilecommons.profile_update mobile:%s form:%s error:%s', phone, JSON.stringify(postData.form), error);
-    }
-    else if (response && response.statusCode != 200) {
-      logger.error('mobilecommons.profile_update for mobile:'
-        + phone + ' | form data: ' + JSON.stringify(postData.form)
-        + '| with code: ' + response.statusCode
-        + ' | body: ' + body + ' | stack: ' + trace);
-    }
-  };
-
-  var requestRetry = new RequestRetry();
+  
+  const requestRetry = new RequestRetry();
   requestRetry.setRetryConditions([400, 408, 500]);
-  requestRetry.post(url, postData, callback);
+  requestRetry.post(`${uri}/profile_update`, data, (error, response, body) => {
+    const logMsg = `${statName} ${response.statusCode}`;
+    stathat(logMsg);
+
+    if (error) {
+      logger.error(error.message);
+      logger.error(error.stack);
+    }
+  });
 };
+
+/**
+ * Legacy functions.
+ */
 
 /**
  * Opt-in mobile numbers into specified Mobile Commons paths. Can take custom

--- a/server.js
+++ b/server.js
@@ -56,6 +56,7 @@ const logger = app.locals.logger;
  * Load stathat.
  */
 const stathat = require('stathat');
+
 app.locals.stathat = function (statName) {
   const key = process.env.STATHAT_EZ_KEY;
   if (!key) {
@@ -67,13 +68,21 @@ app.locals.stathat = function (statName) {
   const stat = `${appName} - ${statName}`;
 
   // Bump count of stat by 1.
-  stathat.trackEZCount(key, stat, 1, status => logger.verbose(`stathat ${stat}:${status}`));
+  stathat.trackEZCount(key, stat, 1, status => logger.verbose(`stathat:${stat} ${status}`));
 };
 
 if (!process.env.CAMPAIGNBOT_CAMPAIGNS) {
   app.locals.logger.error('process.env.CAMPAIGNBOT_CAMPAIGNS undefined');
   process.exit(1);
 }
+
+app.locals.stathatError = function (statName, error) {
+  if (error.status) {
+    app.locals.stathat(`${statName} ${error.status}`);
+  } else {
+    app.locals.stathat(`${statName} failed`);
+  }
+};
 
 const loader = require('./config/locals');
 

--- a/server.js
+++ b/server.js
@@ -143,7 +143,7 @@ conn.on('connected', () => {
       return campaigns.forEach((campaign) => {
         const campaignID = campaign._id;
         app.locals.campaigns[campaignID] = campaign;
-        logger.debug(`loaded app.locals.campaigns[${campaignID}]`);
+        logger.info(`loaded app.locals.campaigns[${campaignID}]`);
 
         if (!campaign.mobilecommons_group_doing || !campaign.mobilecommons_group_completed) {
           campaign.createMobileCommonsGroups();
@@ -155,7 +155,7 @@ conn.on('connected', () => {
         campaign.keywords.forEach((campaignKeyword) => {
           const keyword = campaignKeyword.toLowerCase();
           app.locals.keywords[keyword] = campaignID;
-          logger.debug(`loaded app.locals.db.keywords[${keyword}]:${campaignID}`);
+          logger.info(`loaded app.locals.keywords[${keyword}]:${campaignID}`);
         });
       });
     })


### PR DESCRIPTION
#### What's this PR do?
* Fixes a bug missed in #723 to restore delivering external Signup confirmation messages -- was still calling `CampaignBotController.renderResponseMessage`
* Fires stathat event for Mobile Commons `profile_update` response
* Prefaces DS API stathat names with either `'northstar:'` or `'phoenix:'` to better indicate networking events
* Adds `stathatError(statName, error)` function to DRY checking/logging `error.status`

#### How should this be reviewed?
Deploy to staging, 👀 stathat

#### Relevant tickets
Last task left of #714 (and #726) is adding events for misconfiguration. Ideally there we'd want some email alerts and not just stathat events.

#### Checklist
- [x] Tested on staging.
