### PR TITLE
Fixes bug in #728

### DIFF
--- a/lib/mobilecommons.js
+++ b/lib/mobilecommons.js
@@ -45,7 +45,7 @@ exports.profile_update = function(profileId, phone, oip, updateFields) {
 
   const data = { auth, form: {} };
   const fieldNames = Object.keys(updateFields);
-  data.form = fieldNames.map((fieldName) =>  updateFields[fieldName]);
+  fieldNames.forEach(fieldName => data.form[fieldName] = updateFields[fieldName]);
   data.form.phone_number = phone;
   data.form.opt_in_path_id = oip;
   


### PR DESCRIPTION
#### What's this PR do?
* Fixes `mobilecommons.profile_update` to save profile properly.

I missed this because I didn't pay attention to the text that Mobile Commons sent me -- it was sending me the last saved message to my profile -- not the message I should have expected to get back from the endpoint I was testing from (`/v1/donorschoosebot`)  

#### How should this be reviewed?
Text in a staging keyword upon deploy

#### Any background context you want to provide?
Just now,[ Mobile Commons messages sent to my phone while testing started failing](https://cloud.githubusercontent.com/assets/1236811/20111094/dd65c79e-a59b-11e6-90d4-e1a7d06f8107.png)... curious if somehow this is related. Messages were failing yesterday too, and have been intermittently since I've been on the project



#### Relevant tickets
#728

#### Checklist
- [x] Tested on staging.

