### PR TITLE
BotRequest model

### DIFF
--- a/app/models/BotRequest.js
+++ b/app/models/BotRequest.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * Models a conversation request to Gambit API.
+ */
+const mongoose = require('mongoose');
+
+const botRequestSchema = new mongoose.Schema({
+
+  created_at: { type: Date, default: Date.now() },
+  client: String,
+  query: Object,
+  body: Object,
+  user_id: String,
+  campaign_id: Number,
+  bot_type: String,
+  bot_id: String,
+  bot_response_type: String,
+  bot_response_message: String,
+
+});
+
+/**
+ * Creates BotRequest model for given incoming Express request.
+ * @param {object} req - Express request
+ * @param {string} botType - Type of bot handling response (campaignbot, donorschoosebot)
+ * @param {string} msgType - Type of bot message to respond back with
+ * @param {string} msg - Rendered bot response message text
+ * @param {Signup} signup - Signup model. If set, stores user and campaign ID's.
+ */
+botRequestSchema.statics.log = function (req, botType, botId, msgType, msg) {
+  const data = {
+    client: req.client,
+    query: req.query,
+  };
+
+  if (req.client === 'mobilecommons') {
+    data.body = {};
+    const properties = [
+      'args',
+      'broadcast_id',
+      'keyword',
+      'mdata_id',
+      'message_id',
+      'mms_image_url',
+      'phone',
+      'profile_id',
+    ];
+    properties.forEach((property) => {
+      data.body[property] = req.body[property];
+    });
+  } else {
+    data.body = req.body;
+  }
+  if (req.user) {
+    data.user_id = req.user._id;
+  }
+  if (req.campaign) {
+    data.campaign_id = req.campaign._id;
+  }
+  data.bot_type = botType;
+  data.bot_id = botId;
+  data.bot_response_type = msgType;
+  data.bot_response_message = msg;
+
+  return this.create(data);
+};
+
+module.exports = function (connection) {
+  return connection.model('bot_requests', botRequestSchema);
+};

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -72,6 +72,8 @@ donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
     msg = msg.replace('{{url}}', req.donation.proposal_url);
   }
 
+  app.locals.db.bot_requests.log(req, 'donorschoosebot', this._id, msgType, msg);
+
   return msg;
 };
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -32,6 +32,8 @@ router.post('/', (req, res) => {
   const campaignBot = app.locals.campaignBot;
 
   const scope = req;
+  // Currently only support mobilecommons.
+  scope.client = 'mobilecommons';
   scope.oip = process.env.MOBILECOMMONS_OIP_CHATBOT;
   scope.incoming_message = req.body.args;
   scope.incoming_image_url = req.body.mms_image_url;

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -66,6 +66,8 @@ router.post('/', (req, res) => {
 
   let incomingMessage = req.body.args;
   const scope = req;
+  // Currently only support mobilecommons.
+  scope.client = 'mobilecommons';
   // Initialize object to store profile data to save when posting Mobile Commons profile_update API.
   scope.profile_update = {};
 

--- a/config/locals.js
+++ b/config/locals.js
@@ -8,6 +8,7 @@ const logger = app.locals.logger;
 module.exports.getModels = function (conn) {
   const models = {};
   // Indexed by collection name:
+  models.bot_requests = rootRequire('app/models/BotRequest')(conn);
   models.campaigns = rootRequire('app/models/Campaign')(conn);
   models.campaignbots = rootRequire('app/models/CampaignBot')(conn);
   models.donorschoosebots = rootRequire('app/models/DonorsChooseBot')(conn);


### PR DESCRIPTION
#### What's this PR do?
Takes our Gambit Stathat events for bot messages in #726 a step further by storing them in a new `bot_requests` collection in the Gambit DB.

*  Log incoming POST requests to `/chatbot`, `/donorschoosebot`, and `/signups` along with the Bot response back:
    * `bot` -- The Bot that responded (`campaignbot`, `donorschoosebot`, future Onboarding, SMS Games, Account Management Bots that we need CMS's like Gambit Jr to maintain copy in)
   * `bot_msg_type` -- The type of Bot message we're sending back as a response, e.g. `'ask_zip'`, `'menu_completed'`)
    * `bot_msg` -- The rendered response message to deliver back to the User

* Adds a `client` property to our incoming Express request to determine which body properties to store.

    * `mobilecommons` -- incoming Mobile Commons mData request. If set, we store things like the `broadcast_id`, which is critical for Signup Broadcast Support #651 to gather analytics for how many Users signup from a given Campaign Signup Broadcast (filter by `body.broadcast_id` and `bot_response_type === 'msg_menu_signedup_gambit`)

    * `external-signup`  -- incoming Quicksilver request to trigger the CampaignBot External Signup Confirmation message (`msg_menu_signedup_external`)

#### How should this be reviewed?
1. I could use some second opinions on all names (both of `bot_requests` and all its fields), and exactly what messages we want to store. Am I missing anything?  Do the names make sense?

2. Currently logging all triggered External Signup confirmation messages -- but we sure send thousands and thousands of them. Still, seems like it would be odd not to. It would also help us catch if we happened to send multiple external confirmation messages if there were bugs.

3. I'll deploy to staging, and post around the various endpoints to start populating the table. Please take a look at live staging  `bot_requests` data and confirm 🆗 . Need access to the staging DB? There's [an app for that](https://github.com/DoSomething/ServerConfig/wiki/4.0-Gambit#staging).


#### Relevant tickets
Fixes #698 

#### Checklist
- [x] Tested on staging.

cc @deadlybutter @mshmsh5000 @sheyd 
