### PR TITLE
Fixes External Signup messages

### DIFF
--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -71,6 +71,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   let msg = this[botProperty];
   const campaign = req.campaign;
   if (!campaign) {
+    stathat('campaignbot: undefined campaign');
     logger.error('renderMessage req.campaign undefined');
 
     return msg;


### PR DESCRIPTION
#### What's this PR do?
* Fixes bug introduced in #733, where the Express request sent to `CampaignBot.renderMessage(req, msgType, prefix)` didn't contain a loaded `Campaign` model -- just the Campaign Id.
* Adds additional check to see if the Gambit campaign document has a closed status, and throws error if so. Otherwise User would try to start the Campaign and receive the CampaignBot message for closed campaigns.

#### How should this be reviewed?
* Upon deploy, post one of your CampaignBot Staging Signup Id's to the  `/signups` endpoint with source != 'sms-mobilecommons
* Confirm the rendered text contains the correct Campaign variables, and not just undefined. 
* Confirm your `users` document has the correct `current_campaign` set, for the Signup you just posted

#### Any background context you want to provide?
We could throw an error instead of an undefined... but could may be instances where we don't need a loaded Campaign in `CampaignBot.renderResponse`. For sake of hotfixing and deploying asap -- holding off on throwing an error.

#### Relevant tickets
Fixes #736

#### Checklist
- [x] Tested on staging.


