### PR TITLE
Fixes isYesResponse bug from #733

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -85,7 +85,7 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = req.keyword;
+    const ask = req.keyword || req.query.broadcast;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);

--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -85,7 +85,7 @@ class CampaignBotController {
     this.debug(req, 'continueReportbackSubmission');
 
     const submission = req.signup.draft_reportback_submission;
-    const ask = req.keyword || req.query.broadcast;
+    const ask = req.keyword || req.broadcast_id;
 
     if (!submission.quantity) {
       return this.collectReportbackProperty(req, 'quantity', ask);

--- a/app/models/BotRequest.js
+++ b/app/models/BotRequest.js
@@ -47,7 +47,9 @@ botRequestSchema.statics.log = function (req, botType, botId, msgType, msg) {
       'profile_id',
     ];
     properties.forEach((property) => {
-      data.body[property] = req.body[property];
+      if (req.body[property]) {
+        data.body[property] = req.body[property];
+      }
     });
   } else {
     data.body = req.body;

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -71,8 +71,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   let msg = this[botProperty];
   const campaign = req.campaign;
   if (!campaign) {
-    stathat('campaignbot: undefined campaign');
-    logger.error('renderMessage req.campaign undefined');
+    logger.debug('renderMessage req.campaign undefined');
 
     return msg;
   }

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -63,7 +63,7 @@ campaignBotSchema.statics.lookupByID = function (id) {
  * @return {string} - CampaignBot message with Liquid tags replaced with req properties
  */
 campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
-  const logMsg = `campaignbot: ${msgType}`;
+  const logMsg = `campaignbot:${msgType}`;
   logger.info(logMsg);
   stathat(logMsg);
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -13,6 +13,8 @@ const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 
 function isCommand(incomingMessage, commandType) {
+  logger.debug(`isCommand:${commandType}`);
+
   if (!incomingMessage) {
     return false;
   }
@@ -108,6 +110,7 @@ router.post('/', (req, res) => {
       let campaignId;
 
       if (req.query.broadcast) {
+        logger.debug('broadcast');
         campaignId = process.env.CAMPAIGNBOT_BROADCAST_CAMPAIGN;
         campaign = app.locals.campaigns[campaignId];
 

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -12,12 +12,6 @@ Name | Type | Description
 --- | --- | ---
 `x-gambit-api-key` | `string` | **Required.**
 
-**Parameters**
-
-Name | Type | Description
---- | --- | ---
-`broadcast` | `boolean` | If set, inspects User's sent message as either Yes or No response to Signup for whatever the `CAMPAIGNBOT_BROADCAST_CAMPAIGN` config var is set to.
-
 
 **Input**
 
@@ -30,6 +24,7 @@ Name | Type | Description
 `mms_image_url` | `string` | Incoming image sent.
 `keyword` | `string` | [Mobile Commons keyword](https://github.com/DoSomething/gambit/wiki/Chatbot#mdata) that triggered the incoming mData POST.
 `profile_id` | `number` | Mobile Commons Profile ID
+`broadcast_id` | `number` | Mobile Commons Broadcast ID, if User is responding to a Broadcast
 
 <details>
 <summary>**Example Request**</summary>

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,7 +82,7 @@ module.exports.getFirstWord = function (message) {
  */
 module.exports.isYesResponse = function(message) {
   var m = message.toUpperCase().trim();
-  m = getFirstWord(m);
+  m = this.getFirstWord(m);
 
   var noResponses = [
     'N',


### PR DESCRIPTION
#### What's this PR do?
* Fixes bug introduced by #733 that throws 500 error upon responding to a Signup Broadcast
* Adds a just a little bit more logging to log when we call `isCommand` and if current request is a response to a Signup Broadcast
* Handles scenario where Signup Broadcast is sent to a User who's already signed up and has a draft Reportback Submission started. Answering Yes would result in the `invalid_zip` response -- instead we send back the next question to ask with the "Picking up where you left off" copy.

#### How should this be reviewed?
* Post to staging ~~`chatbot?broadcast=true`~~ `chatbot` endpoint and include a `broadcast_id` in the request body.
* Verify passing  yes and no responses return either the relevant Signed Up message, or the Signup Broadcast Declined message.

#### Any background context you want to provide?
Think it makes sense to do a minor refactor here -- instead of checking for a `req.query.broadcast` parameter, look for a `req.body.broadcast_id` that gets sent when User is responding to a Mobile Commons broadcast. That would mean we can avoid use of a separate mData for broadcasts entirely, and just use the single Chatbot mData (POST `/v1/chatbot`) for both Chat OIP responses and Broadcast responses.

#### Relevant tickets
Fixes #738

#### Checklist
- [ ] Documentation added for new features/changed endpoints -- list all endpoints to test and scenarios
- [x] Tested on staging.


