### PR TITLE
Adds Chatbot Prefix when CampaignBot message doesn't have a campaign

### DIFF
--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -69,10 +69,14 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
 
   const botProperty = `msg_${msgType}`;
   let msg = this[botProperty];
+  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
   const campaign = req.campaign;
+  // A Broadcast Declined request won't contain a loaded campaign.
   if (!campaign) {
     logger.debug('renderMessage req.campaign undefined');
-
+    if (senderPrefix) {
+      msg = `${senderPrefix} ${msg}`;
+    }
     return msg;
   }
 
@@ -126,7 +130,6 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
     msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;
   }
 
-  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
   if (senderPrefix) {
     msg = `${senderPrefix} ${msg}`;
   }


### PR DESCRIPTION
#### What's this PR do?

Small bug fix in `CampaignBot renderMessage` where the `GAMBIT_CHATBOT_RESPONSE_PREFIX` is not added if the request doesn't contain a loaded `campaign` property.

The `GAMBIT_CHATBOT_RESPONSE_PREFIX` comes in quite handy to verify that a response comes from Gambit Staging vs. Gambit Production.

#### How should this be reviewed?
Post to `v1/chatbot` on Staging, passing a `body.broadcast_id` and various yes / no responses for `body.args`. Verify the Broadcast Declined message is prefixed with "@thor:" (this was the bug -- it wasn't)

#### Any background context you want to provide?
A future-thinking instance where CampaignBot could be passed a request without a loaded Campaign is when we build out a Select Campaign menu, where the current user won't have a selected `current_campaign`.

#### Relevant tickets
#738 

#### Checklist
- [x] Tested on staging.

