### PR TITLE
Makes startup errors readable.

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -26,7 +26,9 @@ module.exports = {
     return superagent.get(`${uri}${path}`)
       .set(apiHeaderName, apiKey)
       .then(res => res.body)
-      .catch(logger.error);
+      .catch((e) => {
+        logger.error(`Messaging groups GET caught an error: ${e.message}`);
+      });
   },
 
   /**
@@ -41,7 +43,9 @@ module.exports = {
       .send(data)
       .set(apiHeaderName, apiKey)
       .then(res => res.body)
-      .catch(logger.error);
+      .catch((e) => {
+        logger.error(`Messaging groups POST caught an error: ${e.message}`);
+      });
   },
 
   /**

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -26,8 +26,8 @@ module.exports = {
     return superagent.get(`${uri}${path}`)
       .set(apiHeaderName, apiKey)
       .then(res => res.body)
-      .catch((e) => {
-        logger.error(`Messaging groups GET caught an error: ${e.message}`);
+      .catch((error) => {
+        logger.error(`Messaging groups GET caught an error: ${error.message}`);
       });
   },
 
@@ -43,8 +43,8 @@ module.exports = {
       .send(data)
       .set(apiHeaderName, apiKey)
       .then(res => res.body)
-      .catch((e) => {
-        logger.error(`Messaging groups POST caught an error: ${e.message}`);
+      .catch((error) => {
+        logger.error(`Messaging groups POST caught an error: ${error.message}`);
       });
   },
 


### PR DESCRIPTION
#### What's this PR do?
Fixes an issue with empty error text like this:
![image](https://cloud.githubusercontent.com/assets/672669/20325180/35b7c74e-ab8c-11e6-81b3-bbcb5c96ccdb.png)

It makes it look like this:
![image](https://cloud.githubusercontent.com/assets/672669/20325205/5623b844-ab8c-11e6-81dd-dc1374405a18.png)

#### How should this be reviewed?
`heroku local`

#### Relevant tickets
@deadlybutter, do you remember the ticket?

#### Checklist
- [x] Tested on staging.

cc @aaronschachter 

