### PR TITLE
chatbot.fetchCampaign

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -159,16 +159,16 @@ class CampaignBotController {
    * @return {string}
    */
   loggerPrefix(req) {
-    let userID = null;
+    let userId = null;
     if (req.user) {
-      userID = req.user._id;
+      userId = req.user._id;
     }
-    let campaignID = null;
+    let campaignId = null;
     if (req.campaign) {
-      campaignID = req.campaign._id;
+      campaignId = req.campaign.id;
     }
 
-    return `campaignBot.campaign:${campaignID} user:${userID}`;
+    return `campaignBot.campaign:${campaignId} user:${userId}`;
   }
 
   /**

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -5,6 +5,7 @@
  */
 const mongoose = require('mongoose');
 const logger = app.locals.logger;
+const helpers = require('../../lib/helpers');
 const MessagingGroups = require('../../lib/groups');
 
 const campaignSchema = new mongoose.Schema({
@@ -15,13 +16,8 @@ const campaignSchema = new mongoose.Schema({
   // Properties cached from DS API.
   title: String,
   current_run: Number,
-  fact_problem: String,
-  msg_rb_confirmation: String,
-  rb_noun: String,
-  rb_verb: String,
-  status: { type: String, enum: ['active', 'closed'] },
-  tagline: String,
-  type: String,
+  // TODO: Deprecate this. Keep for now as its used by the campaigns/:id/message route.
+  status: String,
 
   // Properties to override CampaignBot content.
   msg_ask_caption: String,
@@ -49,19 +45,13 @@ const campaignSchema = new mongoose.Schema({
 
 function parsePhoenixCampaign(phoenixCampaign) {
   const data = {
-    status: phoenixCampaign.status,
-    tagline: phoenixCampaign.tagline,
     title: phoenixCampaign.title,
+    status: phoenixCampaign.status,
     current_run: phoenixCampaign.currentCampaignRun.id,
-    fact_problem: phoenixCampaign.facts.problem,
-    msg_rb_confirmation: phoenixCampaign.reportbackInfo.confirmationMessage,
-    rb_noun: phoenixCampaign.reportbackInfo.noun,
-    rb_verb: phoenixCampaign.reportbackInfo.verb,
   };
 
   return data;
 }
-
 
 /**
  * Get given Campaigns from DS API then store.
@@ -117,17 +107,10 @@ campaignSchema.methods.findOrCreateMessagingGroups = function () {
  * Returns formatted Campaign object to return in campaigns endpoint.
  */
 campaignSchema.methods.formatApiResponse = function () {
-  let campaignBotCampaign = false;
-  if (app.locals.campaigns[this._id]) {
-    campaignBotCampaign = true;
-  }
-
-  // TODO: Add all other properties.
   const data = {
     id: this._id,
     title: this.title,
-    campaignbot: campaignBotCampaign,
-    status: this.status,
+    campaignbot: helpers.isCampaignBotCampaign(this._id),
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,
     mobilecommons_group_completed: this.mobilecommons_group_completed,

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -70,16 +70,8 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   let msg = this[botProperty];
   const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
   const campaign = req.campaign;
-  // A Broadcast Declined request won't contain a loaded campaign.
-  if (!campaign) {
-    logger.debug('renderMessage req.campaign undefined');
-    if (senderPrefix) {
-      msg = `${senderPrefix} ${msg}`;
-    }
-    return msg;
-  }
 
-  // Check if campaign has an override defined.
+  // TODO: db.campaigns.findById to check for override.
   if (campaign[botProperty]) {
     msg = campaign[botProperty];
   }
@@ -95,13 +87,14 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   msg = msg.replace(/{{br}}/gi, '\n');
   msg = msg.replace(/{{title}}/gi, campaign.title);
   msg = msg.replace(/{{tagline}}/i, campaign.tagline);
-  msg = msg.replace(/{{fact_problem}}/gi, campaign.fact_problem);
-  msg = msg.replace(/{{rb_noun}}/gi, campaign.rb_noun);
-  msg = msg.replace(/{{rb_verb}}/gi, campaign.rb_verb);
-  msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.msg_rb_confirmation);
+  msg = msg.replace(/{{fact_problem}}/gi, campaign.facts.problem);
+  msg = msg.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
+  msg = msg.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
+  msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.reportbackInfo.confirmationMessage);
   msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
   msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
+  // TODO: Check campaign model, not Phoenix Campaign object.
   if (campaign.keywords && campaign.keywords.length > 0) {
     let keyword;
     // If user signed up via keyword and there are multiple, use the keyword they signed up with.

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -66,18 +66,21 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   logger.info(logMsg);
   stathat(logMsg);
 
+  const campaign = req.campaign;
+  if (!campaign.id) {
+    throw new Error('req.campaign undefined');
+  }
+
   const botProperty = `msg_${msgType}`;
   let msg = this[botProperty];
-  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
-  const campaign = req.campaign;
-
-  // TODO: db.campaigns.findById to check for override.
-  if (campaign[botProperty]) {
-    msg = campaign[botProperty];
+  // TODO: Use db.campaigns.findById to check for overrides/keywords instead of app.locals.campaigns
+  const campaignDoc = app.locals.campaigns[campaign.id];
+  if (campaignDoc[botProperty]) {
+    msg = campaignDoc[botProperty];
   }
 
   if (!msg) {
-    return this.error(req, 'bot msgType not found');
+    throw new Error(`bot msgType:${msgType} not found`);
   }
 
   if (prefix) {
@@ -94,15 +97,14 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
   msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
-  // TODO: Check campaign model, not Phoenix Campaign object.
-  if (campaign.keywords && campaign.keywords.length > 0) {
+  if (campaignDoc.keywords && campaignDoc.keywords.length > 0) {
     let keyword;
     // If user signed up via keyword and there are multiple, use the keyword they signed up with.
-    const usedSignupKeyword = campaign.keywords.length > 1 && req.signup && req.signup.keyword;
+    const usedSignupKeyword = campaignDoc.keywords.length > 1 && req.signup && req.signup.keyword;
     if (usedSignupKeyword) {
       keyword = req.signup.keyword;
     } else {
-      keyword = campaign.keywords[0];
+      keyword = campaignDoc.keywords[0];
     }
     msg = msg.replace(/{{keyword}}/i, keyword.toUpperCase());
   }
@@ -122,6 +124,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
     msg = `${continueMsg} ${campaign.title}...\n\n${msg}`;
   }
 
+  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
   if (senderPrefix) {
     msg = `${senderPrefix} ${msg}`;
   }

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -63,6 +63,8 @@ router.post('/:id/message', (req, res) => {
   }
 
   // Check that campaign is active.
+  // TODO: Refactor this to no longer use app.locals.campaigns -- would need to query Phoenix API
+  // to check for Campaign Status.
   const campaign = app.locals.campaigns[campaignId];
   if (!campaign || campaign.status !== 'active') {
     const msg = `Campaign ${campaignId} is not running on CampaignBot`;

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -191,7 +191,7 @@ router.post('/', (req, res) => {
 
           return fetchCampaign(campaignId)
             .then((campaign) => {
-              if (!campaign) {
+              if (!campaign.id) {
                 const msg = `Campaign not found for keyword '${scope.keyword}'.`;
                 const err = new NotFoundError(msg);
                 return reject(err);
@@ -215,7 +215,7 @@ router.post('/', (req, res) => {
         logger.debug(`user.current_campaign:${user.current_campaign}`);
         return fetchCampaign(user.current_campaign)
           .then((campaign) => {
-            if (!campaign) {
+            if (!campaign.id) {
               // TODO: Send to non-existent start menu to select a campaign.
               const msg = `User ${user._id} current_campaign ${user.current_campaign} not found.`;
               const err = new NotFoundError(msg);

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -13,9 +13,17 @@ const mobilecommons = require('../../lib/mobilecommons');
 const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 
+/**
+ * Fetches Campaign object from DS API for given id.
+ */
 function fetchCampaign(id) {
   return new Promise((resolve, reject) => {
     logger.debug(`fetchCampaign:${id}`);
+
+    if (!id) {
+      const err = new NotFoundError('Campaign id undefined');
+      return reject(err);
+    }
 
     return app.locals.clients.phoenix.Campaigns
       .get(id)
@@ -24,6 +32,9 @@ function fetchCampaign(id) {
   });
 }
 
+/**
+ * Determines if given incomingMessage matches given Gambit command type.
+ */
 function isCommand(incomingMessage, commandType) {
   logger.debug(`isCommand:${commandType}`);
 
@@ -170,7 +181,8 @@ router.post('/', (req, res) => {
               }
 
               return resolve(campaign);
-            });
+            })
+            .catch(err => reject(err));
         }
 
         if (scope.keyword) {
@@ -195,7 +207,8 @@ router.post('/', (req, res) => {
               }
 
               return resolve(campaign);
-            });
+            })
+            .catch(err => reject(err));
         }
 
         // If we've made it this far, check for User's current_campaign.

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -13,6 +13,17 @@ const mobilecommons = require('../../lib/mobilecommons');
 const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 
+function fetchCampaign(id) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`fetchCampaign:${id}`);
+
+    return app.locals.clients.phoenix.Campaigns
+      .get(id)
+      .then(campaign => resolve(campaign))
+      .catch(err => reject(err));
+  });
+}
+
 function isCommand(incomingMessage, commandType) {
   logger.debug(`isCommand:${commandType}`);
 
@@ -116,8 +127,8 @@ router.post('/', (req, res) => {
 
   const loadCampaign = new Promise((resolve, reject) => {
     logger.log('loadCampaign');
-    let campaign;
     let campaignId;
+    let currentBroadcast;
 
     return loadUser
       .then((user) => {
@@ -132,25 +143,26 @@ router.post('/', (req, res) => {
                 const err = new NotFoundError('broadcast undefined');
                 return reject(err);
               }
-
-              logger.info(`loaded broadcast:${broadcast._id}`);
-              campaignId = broadcast.campaign;
-              campaign = app.locals.campaigns[campaignId];
-              if (!campaign) {
+              currentBroadcast = broadcast;
+              logger.info(`loaded broadcast:${currentBroadcast._id}`);
+              return fetchCampaign(currentBroadcast.campaign);
+            })
+            .then((campaign) => {
+              if (!campaign.id) {
                 const err = new Error('broadcast campaign undefined');
                 return reject(err);
               }
 
-              logger.info(`loaded campaign:${campaign._id}`);
+              logger.info(`loaded campaign:${campaign.id}`);
 
               if (campaign.status === 'closed') {
                 // TODO: Include this message to the CampaignClosedError.
-                const msg = `Broadcast Campaign ${campaignId} is closed.`;
+                const msg = `Broadcast Campaign ${campaign.id} is closed.`;
                 const err = new UnprocessibleEntityError(msg);
                 return reject(err);
               }
 
-              scope.broadcast = broadcast;
+              scope.broadcast = currentBroadcast;
               const saidNo = !(req.incoming_message && helpers.isYesResponse(req.incoming_message));
               if (saidNo) {
                 const err = new Error('broadcast declined');
@@ -164,43 +176,48 @@ router.post('/', (req, res) => {
         if (scope.keyword) {
           logger.debug(`load campaign for keyword:${scope.keyword}`);
           campaignId = app.locals.keywords[scope.keyword];
-          campaign = app.locals.campaigns[campaignId];
 
-          if (!campaign) {
-            const msg = `Campaign not found for keyword '${scope.keyword}'.`;
-            const err = new NotFoundError(msg);
-            return reject(err);
-          }
+          return fetchCampaign(campaignId)
+            .then((campaign) => {
+              if (!campaign) {
+                const msg = `Campaign not found for keyword '${scope.keyword}'.`;
+                const err = new NotFoundError(msg);
+                return reject(err);
+              }
 
-          if (campaign.status === 'closed') {
-            // Store campaign to render in closed message.
-            scope.campaign = campaign;
-            // TODO: Include this message to the CampaignClosedError.
-            const msg = `Keyword received for closed campaign ${campaignId}.`;
-            const err = new UnprocessibleEntityError(msg);
-            return reject(err);
-          }
+              if (campaign.status === 'closed') {
+                // Store campaign to render in closed message.
+                scope.campaign = campaign;
+                // TODO: Include this message to the CampaignClosedError.
+                const msg = `Keyword received for closed campaign ${campaignId}.`;
+                const err = new UnprocessibleEntityError(msg);
+                return reject(err);
+              }
 
-          return resolve(campaign);
+              return resolve(campaign);
+            });
         }
 
-        campaign = app.locals.campaigns[user.current_campaign];
+        // If we've made it this far, check for User's current_campaign.
         logger.debug(`user.current_campaign:${user.current_campaign}`);
+        return fetchCampaign(user.current_campaign)
+          .then((campaign) => {
+            if (!campaign) {
+              // TODO: Send to non-existent start menu to select a campaign.
+              const msg = `User ${user._id} current_campaign ${user.current_campaign} not found.`;
+              const err = new NotFoundError(msg);
 
-        if (!campaign) {
-          // TODO: Send to non-existent start menu to select a campaign.
-          const msg = `User ${user._id} current_campaign ${campaignId} not found in CampaignBot.`;
-          const err = new NotFoundError(msg);
-          return reject(err);
-        }
+              return reject(err);
+            }
 
-        return resolve(campaign);
+            return resolve(campaign);
+          });
       });
   });
 
   return loadCampaign
     .then((campaign) => {
-      logger.log(`loaded campaign:${campaign._id}`);
+      logger.log(`loaded campaign:${campaign.id}`);
       scope.campaign = campaign;
 
       return app.locals.db.signups.lookupCurrent(scope.user, scope.campaign);
@@ -262,11 +279,11 @@ router.post('/', (req, res) => {
     .then((msg) => {
       scope.response_message = msg;
       // Save to continue conversation with future mData requests that don't contain a keyword.
-      scope.user.current_campaign = scope.campaign._id;
+      scope.user.current_campaign = scope.campaign.id;
       return scope.user.save();
     })
     .then(() => {
-      logger.debug(`saved user.current_campaign:${scope.campaign._id}`);
+      logger.debug(`saved user.current_campaign:${scope.campaign.id}`);
       scope.user.postMobileCommonsProfileUpdate(scope.oip, scope.response_message);
 
       return helpers.sendResponse(res, 200, scope.response_message);

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -39,6 +39,7 @@ router.post('/', (req, res) => {
     .lookupById(signupId)
     .then((signup) => {
       scope.signup = signup;
+      // TODO: Use findById instead of app.locals.campaigns.
       scope.campaign = app.locals.campaigns[signup.campaign];
 
       if (!scope.campaign) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,9 +14,14 @@ const logger = app.locals.logger;
  * Returns whether given Campaign id is enabled for CampaignBot.
  */
 module.exports.isCampaignBotCampaign = function (campaignId) {
-  const ids = process.env.CAMPAIGNBOT_CAMPAIGNS;
+  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled if a keyword exists for
+  // its id (and its campaign.status is active).
+  const campaignDoc = app.locals.campaigns[campaignId];
+  if (!campaignDoc._id) {
+    return false;
+  }
 
-  return ids.includes(campaignId);
+  return true;
 };
 
 module.exports.isValidZip = function (zip) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -16,12 +16,7 @@ const logger = app.locals.logger;
 module.exports.isCampaignBotCampaign = function (campaignId) {
   // TODO: We'll eventually determine if a CampaignBotCampaign is enabled if a keyword exists for
   // its id (and its campaign.status is active).
-  const campaignDoc = app.locals.campaigns[campaignId];
-  if (!campaignDoc._id) {
-    return false;
-  }
-
-  return true;
+  return !!app.locals.campaigns[campaignId]._id;
 };
 
 module.exports.isValidZip = function (zip) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,6 +9,16 @@ const logger = app.locals.logger;
 /**
  * Helper functions.
  */
+
+/**
+ * Returns whether given Campaign id is enabled for CampaignBot.
+ */
+module.exports.isCampaignBotCampaign = function (campaignId) {
+  const ids = process.env.CAMPAIGNBOT_CAMPAIGNS;
+
+  return ids.includes(campaignId);
+};
+
 module.exports.isValidZip = function (zip) {
   return /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip);
 };

--- a/server.js
+++ b/server.js
@@ -140,25 +140,28 @@ conn.on('connected', () => {
       logger.debug(`app.locals.db.campaigns.lookupByIDs found ${campaigns.length} campaigns`);
 
       return campaigns.forEach((campaign) => {
-        const campaignID = campaign._id;
-        app.locals.campaigns[campaignID] = campaign;
-        logger.info(`loaded app.locals.campaigns[${campaignID}]`);
+        const campaignId = campaign._id;
+        // Eventually looking to deprecate app.locals.campaigns, leaving for now
+        // as its used by the campaigns/:id/message route.
+        app.locals.campaigns[campaignId] = campaign;
+        logger.info(`loaded app.locals.campaigns[${campaignId}]`);
+
+        if (campaign.keywords.length < 1) {
+          logger.warn(`no keywords defined for campaign:${campaignId}`);
+        }
+
+        campaign.keywords.forEach((campaignKeyword) => {
+          const keyword = campaignKeyword.toLowerCase();
+          app.locals.keywords[keyword] = campaignId;
+          logger.info(`loaded app.locals.keywords[${keyword}]:${campaignId}`);
+        });
 
         if (!campaign.mobilecommons_group_doing || !campaign.mobilecommons_group_completed) {
           campaign.findOrCreateMessagingGroups();
         }
-
-        if (campaign.keywords.length < 1) {
-          logger.warn(`no keywords defined for campaign:${campaignID}`);
-        }
-        campaign.keywords.forEach((campaignKeyword) => {
-          const keyword = campaignKeyword.toLowerCase();
-          app.locals.keywords[keyword] = campaignID;
-          logger.info(`loaded app.locals.keywords[${keyword}]:${campaignID}`);
-        });
       });
     })
-    .catch(err => logger.error(err));
+    .catch(err => logger.error(err.message));
 
   /**
    * Load controllers.


### PR DESCRIPTION
#### What's this PR do?
* Adds a `fetchCampaign` helper function to `routes/chatbot` -- refactors to fetch a DS Campaign from the Phoenix API upon each request, instead of referencing the cached `app.locals.campaigns` Campaign document that only gets updated on app start

* Removes document properties like `rb_noun` and `rb_verb` that the CampaignBot no longer uses 
to render messages

* Clean up `objectID` variables as `objectId` (refs https://github.com/DoSomething/gambit/pull/697#discussion_r85598802)

* Adds TODOs for all code that references `app.locals.campaigns` -- which we'll likely get rid of always just `findById` (or better yet -- query Contentful)

#### How should this be reviewed?
Test the full flow for:
- Campaign that all CampaignBot default messages
- Campaign that has CampaignBot overrides in ithe `campaigns` DB

#### Any background context you want to provide?

* By querying the Phoenix API for the campaign's status every request, we avoid gotchas like #764 -- where the Gambit needs to be restarted to refresh Campaign cache to update status

* Leaving out refactoring of the `campaign/:id/message` and /signups` endpoints for now to help keep these changes reviewable, and testable.

#### Relevant tickets
#775, #764

#### Checklist
- [x] Tested on staging.

