### PR TITLE
Expose messages, overrides objects in Campaigns endpoint

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -109,13 +109,28 @@ campaignSchema.methods.findOrCreateMessagingGroups = function () {
 campaignSchema.methods.formatApiResponse = function () {
   const data = {
     id: this._id,
-    title: this.title,
     campaignbot: helpers.isCampaignBotCampaign(this._id),
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,
     mobilecommons_group_completed: this.mobilecommons_group_completed,
     keywords: this.keywords,
+    messages: this.messages,
+    overrides: {},
   };
+
+  const overrides = [
+    'msg_ask_caption',
+    'msg_ask_photo',
+    'msg_ask_quantity',
+    'msg_ask_why_participated',
+    'msg_invalid_quantity',
+    'msg_member_support',
+    'msg_menu_completed',
+    'msg_menu_signedup_external',
+    'msg_menu_signedup_gambit',
+    'msg_no_photo_sent',
+  ];
+  overrides.forEach(property => (data.overrides[property] = this[property]));
 
   return data;
 };


### PR DESCRIPTION
#### What's this PR do?
Exposes the `messages` object, and any overridden CampaignBot messages as an `overrides` object.

#### How should this be reviewed?
Check the `campaigns` API response, verify data is exposed if it exists.
<img width="611" alt="api response" src="https://cloud.githubusercontent.com/assets/1236811/22560687/5ed6ede0-e92a-11e6-84c5-9a1de410e4e3.png">

#### Any background context you want to provide?
This makes it easier to check what overrides have been set, and will be handy for refactoring Gambit Jr.  / `campaigns` DB collection as Contentful content types in #775 


#### Relevant tickets
Prep for #775

#### Checklist
- [x] Tested on staging.

