### PR TITLE
Fix Campaigns endpoint

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -54,7 +54,7 @@ router.get('/:id', (req, res) => {
 });
 
 /**
- * Sends SMS message to given phone number with the given Campaign and its message type .
+ * Sends SMS message to given phone number with the given Campaign and its message type.
  */
 router.post('/:id/message', (req, res) => {
   // Check required parameters.

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -8,6 +8,9 @@ const mobilecommons = rootRequire('lib/mobilecommons');
 const logger = app.locals.logger;
 const stathat = app.locals.stathat;
 
+/**
+ * GET index of campaigns.
+ */
 router.get('/', (req, res) => {
   stathat('route: v1/campaigns');
 
@@ -25,27 +28,34 @@ router.get('/', (req, res) => {
       const data = campaigns.map(campaign => campaign.formatApiResponse());
       res.send({ data });
     })
-    .catch(error => res.send(error));
+    .catch(error => helpers.sendResponse(res, 500, error.message));
 });
 
+/**
+ * GET single campaign.
+ */
 router.get('/:id', (req, res) => {
   stathat('route: v1/campaigns/{id}');
-  logger.debug(`get campaign ${req.params.id}`);
+  const campaignId = req.params.id;
+  logger.debug(`get campaign ${campaignId}`);
 
   return app.locals.db.campaigns
-    .findById(req.params.id)
+    .findById(campaignId)
     .exec()
     .then(campaign => {
       if (!campaign) {
-        return res.sendStatus(404);
+        return helpers.sendResponse(res, 404, `Campaign ${campaignId} found`);
       }
       const data = campaign.formatApiResponse();
 
       return res.send({ data });
     })
-    .catch(error => res.send(error));
+    .catch(error => helpers.sendResponse(res, 500, error.message));
 });
 
+/**
+ * Sends SMS message to given phone number with the given Campaign and its message type .
+ */
 router.post('/:id/message', (req, res) => {
   // Check required parameters.
   const campaignId = req.params.id;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,7 @@ const logger = app.locals.logger;
  * Returns whether given Campaign id is enabled for CampaignBot.
  */
 module.exports.isCampaignBotCampaign = function (campaignId) {
-  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled it has a live keyword.
+  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled if it has a live keyword.
   // @see https://github.com/DoSomething/gambit/issues/775
   return !!app.locals.campaigns[campaignId];
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,9 +14,9 @@ const logger = app.locals.logger;
  * Returns whether given Campaign id is enabled for CampaignBot.
  */
 module.exports.isCampaignBotCampaign = function (campaignId) {
-  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled if a keyword exists for
-  // its id (and its campaign.status is active).
-  return !!app.locals.campaigns[campaignId]._id;
+  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled it has a live keyword.
+  // @see https://github.com/DoSomething/gambit/issues/775
+  return !!app.locals.campaigns[campaignId];
 };
 
 module.exports.isValidZip = function (zip) {


### PR DESCRIPTION
#### What's this PR do?
* Fixes #780, which was introduced in #777 in by `helpers.isCampaignBotCampaign`. When a Campaign is not a CampaignBot campaign, we'd get the error `Cannot read property '_id' of undefined`

* Calls `helpers.sendResponse` for errors to fix outputting errors

#### How should this be reviewed?
Upon staging deploy, verify: 
- http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns 
- http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/362

#### Any background context you want to provide?
Looking to change `isCampaignBotCampaign` logic by checking to see if there any keywords that exist for the given Campaign. If no keywords are found -- it's not on CampaignBot.

#### Relevant tickets
Fixes #780 

#### Checklist
- [x] Tested on staging.
