### PR TITLE
Refactor Keywords to query Contentful 

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -113,7 +113,6 @@ campaignSchema.methods.formatApiResponse = function () {
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,
     mobilecommons_group_completed: this.mobilecommons_group_completed,
-    keywords: this.keywords,
     messages: this.messages,
     overrides: {},
   };

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -11,7 +11,6 @@ const MessagingGroups = require('../../lib/groups');
 const campaignSchema = new mongoose.Schema({
 
   _id: { type: Number, index: true },
-  keywords: [String],
 
   // Properties cached from DS API.
   title: String,

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -106,7 +106,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
       // TODO: When Signup was external there's no keyword. Query Contentful to find 1st keyword...
       // or stick with the MENU to select campaign instead of directly texting Campaign keyword.
     }
-    msg = msg.replace(/{{keyword}}/gi, keyword.toUpperCase());
+    msg = msg.replace(/{{keyword}}/i, keyword.toUpperCase());
   }
 
   if (req.signup) {

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -75,7 +75,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   let msg = this[botProperty];
   // TODO: Use db.campaigns.findById to check for overrides/keywords instead of app.locals.campaigns
   const campaignDoc = app.locals.campaigns[campaign.id];
-  if (campaignDoc[botProperty]) {
+  if (campaignDoc && campaignDoc[botProperty]) {
     msg = campaignDoc[botProperty];
   }
 
@@ -97,7 +97,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
   msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
-  if (campaignDoc.keywords && campaignDoc.keywords.length > 0) {
+  if (campaignDoc && campaignDoc.keywords && campaignDoc.keywords.length > 0) {
     let keyword;
     // If user signed up via keyword and there are multiple, use the keyword they signed up with.
     const usedSignupKeyword = campaignDoc.keywords.length > 1 && req.signup && req.signup.keyword;

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -97,16 +97,16 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
   msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
   msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
 
-  if (campaignDoc && campaignDoc.keywords && campaignDoc.keywords.length > 0) {
-    let keyword;
-    // If user signed up via keyword and there are multiple, use the keyword they signed up with.
-    const usedSignupKeyword = campaignDoc.keywords.length > 1 && req.signup && req.signup.keyword;
-    if (usedSignupKeyword) {
+  if (msg.indexOf('{{keyword}}') !== -1) {
+    // TODO: Hack for now, we'll need to set up a MENU keyword in Mobile Commons to select Cmapaign.
+    let keyword = 'menu';
+    if (req.signup && req.signup.keyword) {
       keyword = req.signup.keyword;
     } else {
-      keyword = campaignDoc.keywords[0];
+      // TODO: When Signup was external there's no keyword. Query Contentful to find 1st keyword...
+      // or stick with the MENU to select campaign instead of directly texting Campaign keyword.
     }
-    msg = msg.replace(/{{keyword}}/i, keyword.toUpperCase());
+    msg = msg.replace(/{{keyword}}/gi, keyword.toUpperCase());
   }
 
   if (req.signup) {

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -44,7 +44,7 @@ router.get('/', (req, res) => {
   return app.locals.db.campaigns
     .find(findClause)
     .exec()
-    .then((campaignDocs) => Promise.map(campaignDocs, formatCampaignDoc))
+    .then(campaignDocs => Promise.map(campaignDocs, formatCampaignDoc))
     .then(data => res.send({ data }))
     .catch(error => helpers.sendResponse(res, 500, error.message));
 });
@@ -67,7 +67,7 @@ router.get('/:id', (req, res) => {
 
       return formatCampaignDoc(campaignDoc);
     })
-    .then((data) => res.send({ data }))
+    .then(data => res.send({ data }))
     .catch(error => helpers.sendResponse(res, 500, error.message));
 });
 

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -2,11 +2,31 @@
 
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
-
+const Promise = require('bluebird');
+const contentful = require('../../lib/contentful');
 const helpers = require('../../lib/helpers');
 const mobilecommons = rootRequire('lib/mobilecommons');
 const logger = app.locals.logger;
 const stathat = app.locals.stathat;
+
+/**
+ * Queries Contentful to add keywords property to given campaign object.
+ */
+function formatCampaignDoc(campaignDoc) {
+  const campaign = campaignDoc.formatApiResponse();
+
+  return new Promise((resolve, reject) => {
+    logger.debug(`fetchKeywordsForCampaign:${JSON.stringify(campaign)}`);
+
+    return contentful.fetchKeywordsForCampaignId(campaign.id)
+      .then((keywords) => {
+        campaign.keywords = keywords;
+
+        return resolve(campaign);
+      })
+      .catch(error => reject(error));
+  });
+}
 
 /**
  * GET index of campaigns.
@@ -24,10 +44,8 @@ router.get('/', (req, res) => {
   return app.locals.db.campaigns
     .find(findClause)
     .exec()
-    .then((campaigns) => {
-      const data = campaigns.map(campaign => campaign.formatApiResponse());
-      res.send({ data });
-    })
+    .then((campaignDocs) => Promise.map(campaignDocs, formatCampaignDoc))
+    .then(data => res.send({ data }))
     .catch(error => helpers.sendResponse(res, 500, error.message));
 });
 
@@ -42,14 +60,14 @@ router.get('/:id', (req, res) => {
   return app.locals.db.campaigns
     .findById(campaignId)
     .exec()
-    .then(campaign => {
-      if (!campaign) {
-        return helpers.sendResponse(res, 404, `Campaign ${campaignId} found`);
+    .then(campaignDoc => {
+      if (!campaignDoc) {
+        return helpers.sendResponse(res, 404, `Campaign ${campaignId} not found`);
       }
-      const data = campaign.formatApiResponse();
 
-      return res.send({ data });
+      return formatCampaignDoc(campaignDoc);
     })
+    .then((data) => res.send({ data }))
     .catch(error => helpers.sendResponse(res, 500, error.message));
 });
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -29,7 +29,12 @@ function fetchCampaign(id) {
     return app.locals.clients.phoenix.Campaigns
       .get(id)
       .then(campaign => resolve(campaign))
-      .catch(err => reject(err));
+      .catch((err) => {
+        const phoenixError = err;
+        phoenixError.message = `Phoenix: ${err.message}`;
+
+        return reject(phoenixError);
+      });
   });
 }
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -154,6 +154,7 @@ router.post('/', (req, res) => {
                 const err = new NotFoundError(`broadcast ${scope.broadcast_id} not found`);
                 return reject(err);
               }
+              logger.debug(`found broadcast:${JSON.stringify(broadcast)}`);
               currentBroadcast = broadcast;
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
               return fetchCampaign(currentBroadcast.campaignId);
@@ -186,10 +187,16 @@ router.post('/', (req, res) => {
         }
 
         if (scope.keyword) {
-          logger.debug(`load campaign for keyword:${scope.keyword}`);
-          campaignId = app.locals.keywords[scope.keyword];
+          return contentful.fetchKeyword(scope.keyword)
+            .then((keyword) => {
+              if (!keyword) {
+                const err = new NotFoundError(`keyword ${scope.keyword} not found`);
+                return reject(err);
+              }
+              logger.debug(`found keyword:${JSON.stringify(keyword)}`);
 
-          return fetchCampaign(campaignId)
+              return fetchCampaign(keyword.campaignId);
+            })
             .then((campaign) => {
               if (!campaign.id) {
                 const msg = `Campaign not found for keyword '${scope.keyword}'.`;

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -200,6 +200,13 @@ router.post('/', (req, res) => {
               }
               logger.debug(`found keyword:${JSON.stringify(keyword)}`);
 
+              if (keyword.environment !== process.env.NODE_ENV) {
+                let msg = `mData misconfiguration: ${keyword.environment} keyword sent to`;
+                msg = `${msg} ${process.env.NODE_ENV}`;
+                const err = new Error(msg);
+                return reject(err);
+              }
+
               return fetchCampaign(keyword.campaignId);
             })
             .then((campaign) => {

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -144,7 +144,6 @@ router.post('/', (req, res) => {
 
   const loadCampaign = new Promise((resolve, reject) => {
     logger.log('loadCampaign');
-    let campaignId;
     let currentBroadcast;
 
     return loadUser
@@ -220,7 +219,7 @@ router.post('/', (req, res) => {
                 // Store campaign to render in closed message.
                 scope.campaign = campaign;
                 // TODO: Include this message to the CampaignClosedError.
-                const msg = `Keyword received for closed campaign ${campaignId}.`;
+                const msg = `Keyword received for closed campaign ${campaign.id}.`;
                 const err = new UnprocessibleEntityError(msg);
                 return reject(err);
               }
@@ -327,9 +326,7 @@ router.post('/', (req, res) => {
     })
     .catch(UnprocessibleEntityError, (err) => {
       logger.error(err.message);
-      // TODO: Send StatHat report to inform staff CampaignBot is running a closed Campaign.
-      // We don't want to send an error back as response, but instead deliver success to Mobile
-      // Commons and deliver the Campaign Closed message back to our User.
+      stathat('campaign closed');
       const msg = campaignBot.renderMessage(scope, 'campaign_closed');
       // Send to Agent View for now until we get a Select Campaign menu up and running.
       scope.user.postMobileCommonsProfileUpdate(agentViewOip, msg);
@@ -368,6 +365,7 @@ router.post('/', (req, res) => {
       }
 
       logger.error(err.message);
+      stathat(err.message);
 
       return helpers.sendResponse(res, 500, err.message);
     });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -22,23 +22,29 @@ try {
 }
 
 /**
- * Returns the fields defined on the Broadcast content type for a given broadcastId.
+ * Returns first result of a Contentful getEntries call for the given query.
  */
-module.exports.fetchBroadcast = function (broadcastId) {
+function fetchSingleEntry(query) {
   return new Promise((resolve, reject) => {
-    logger.debug(`fetchBroadcast:${broadcastId}`);
-    return client.getEntries({
-      content_type: 'broadcast',
-      'fields.broadcastId': broadcastId,
-    })
+    logger.debug(`contentful.fetchSingleEntry:${JSON.stringify(query)}`);
+    return client.getEntries(query)
     .then((entries) => {
       if (entries.items.length === 0) {
         return resolve(false);
       }
-      const broadcast = entries.items[0];
+      const entry = entries.items[0];
 
-      return resolve(broadcast.fields);
+      return resolve(entry.fields);
     })
     .catch(error => reject(error));
+  });
+}
+
+module.exports.fetchBroadcast = function (broadcastId) {
+  logger.debug(`fetchBroadcast:${broadcastId}`);
+
+  return fetchSingleEntry({
+    content_type: 'broadcast',
+    'fields.broadcastId': broadcastId,
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -41,10 +41,19 @@ function fetchSingleEntry(query) {
 }
 
 module.exports.fetchBroadcast = function (broadcastId) {
-  logger.debug(`fetchBroadcast:${broadcastId}`);
+  logger.debug(`contentful.fetchBroadcast:${broadcastId}`);
 
   return fetchSingleEntry({
     content_type: 'broadcast',
     'fields.broadcastId': broadcastId,
+  });
+};
+
+module.exports.fetchKeyword = function (keyword) {
+  logger.debug(`contentful.fetchKeyword:${keyword}`);
+
+  return fetchSingleEntry({
+    content_type: 'keyword',
+    'fields.keyword': keyword,
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -22,6 +22,16 @@ try {
 }
 
 /**
+ * Prefixes Contentful identifier to given error.message.
+ */
+function contentfulError(error) {
+  const scope = error;
+  scope.message = `Contentful: ${error.message}`;
+
+  return scope;
+}
+
+/**
  * Returns first result of a Contentful getEntries call for the given query.
  */
 function fetchSingleEntry(query) {
@@ -36,7 +46,7 @@ function fetchSingleEntry(query) {
 
       return resolve(entry.fields);
     })
-    .catch(error => reject(error));
+    .catch(error => reject(contentfulError(error)));
   });
 }
 
@@ -56,4 +66,27 @@ module.exports.fetchKeyword = function (keyword) {
     content_type: 'keyword',
     'fields.keyword': keyword,
   });
+};
+
+module.exports.fetchKeywordsForCampaignId = function (campaignId) {
+  logger.debug(`contentful.fetchKeywordsForCampaignId:${campaignId}`);
+  const query = {
+    content_type: 'keyword',
+    'fields.campaignId': campaignId,
+  };
+
+  return client.getEntries(query)
+    .then((response) => {
+      const entries = response.items.map((item) => {
+        if (item.fields) {
+          const keyword = item.fields;
+          delete keyword.campaignId;
+          return keyword;
+        }
+        return null;
+      });
+
+      return entries;
+    })
+    .catch(error => contentfulError(error));
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -77,16 +77,29 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
 
   return client.getEntries(query)
     .then((response) => {
-      const entries = response.items.map((item) => {
-        if (item.fields) {
-          const keyword = item.fields;
-          delete keyword.campaignId;
-          return keyword;
+      // We store keywords for both Thor and Production in our Keywords content type.
+      // Filter the results based on our Node environment:
+      const filteredItems = response.items.filter((item) => {
+        if (!item.fields) {
+          return false;
         }
-        return null;
+        if (item.fields.environment !== process.env.NODE_ENV) {
+          logger.debug(`filtering ${process.env.NODE_ENV} keyword:${item.fields.keyword}`);
+          return false;
+        }
+        return true;
+      });
+      // Remove unnecessary fields.
+      const keywords = filteredItems.map((item) => {
+        const entry = item.fields;
+        delete entry.campaignId;
+        delete entry.environment;
+
+        entry.keyword = entry.keyword.toUpperCase();
+        return entry;
       });
 
-      return entries;
+      return keywords;
     })
     .catch(error => contentfulError(error));
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -42,9 +42,8 @@ function fetchSingleEntry(query) {
       if (entries.items.length === 0) {
         return resolve(false);
       }
-      const entry = entries.items[0];
 
-      return resolve(entry.fields);
+      return resolve(entries.items[0].fields);
     })
     .catch(error => reject(contentfulError(error)));
   });

--- a/server.js
+++ b/server.js
@@ -132,8 +132,6 @@ conn.on('connected', () => {
    * Load campaigns.
    */
   app.locals.campaigns = {};
-  app.locals.keywords = {};
-
   const loadCampaigns = app.locals.db.campaigns
     .lookupByIDs(process.env.CAMPAIGNBOT_CAMPAIGNS)
     .then((campaigns) => {
@@ -145,16 +143,6 @@ conn.on('connected', () => {
         // as its used by the campaigns/:id/message route.
         app.locals.campaigns[campaignId] = campaign;
         logger.info(`loaded app.locals.campaigns[${campaignId}]`);
-
-        if (campaign.keywords.length < 1) {
-          logger.warn(`no keywords defined for campaign:${campaignId}`);
-        }
-
-        campaign.keywords.forEach((campaignKeyword) => {
-          const keyword = campaignKeyword.toLowerCase();
-          app.locals.keywords[keyword] = campaignId;
-          logger.info(`loaded app.locals.keywords[${keyword}]:${campaignId}`);
-        });
 
         if (!campaign.mobilecommons_group_doing || !campaign.mobilecommons_group_completed) {
           campaign.findOrCreateMessagingGroups();


### PR DESCRIPTION
#### What's this PR do?
Upon passing a `keyword`, the `chatbot` router now queries the Contentful `keyword` type to find the `campaignId` associated with it, instead of inspecting the `app.locals.keywords` cache, which is populated from the `campaigns` documents for ids set in `CAMPAIGNBOT_CAMPAIGNS`

This is a big step toward easier configuration: to enable a Campaign for Gambit, add the Keyword and its Campaign ID into Contentful (and add the Keyword on the Mobile Commons mData) -- and the Campaign is live on Gambit. To override Campaignbot messages and/or populate the Campaign's Messaging Group ID's , we still do need to add the ID to `CAMPAIGNBOT_CAMPAIGNS` to populate the Mongo document -- so we're not out of the woods with the config variable and app restart just yet.

## TODO:
* [x]  Support the `{{keyword}}` token in `CampaignBot.renderMessage` -- so we need to add a `getKeywordsForCampaign` function to `lib/contentful`
* [x] Call the `getKeywordsForCampaign` function in the `campaigns` endpoint
* [x] Remove the `keywords` property from the `Campaign` model, and all use of `app.locals.keywords`

#### How should this be reviewed?
Opening this for now to help keep reviewing easier.

#### Any background context you want to provide?
Not ready for merge yet -- more changes on the way.

#### Relevant tickets
#775 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Add staging keywords+campaigns into Contentful
- [x] Tested on staging.
- [x] Add all production keywords+campaigns into Contentful

