### PR TITLE
Starts on Contentful Campaign content type

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -161,7 +161,7 @@ router.post('/', (req, res) => {
               logger.debug(`found broadcast:${JSON.stringify(broadcast)}`);
               currentBroadcast = broadcast;
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
-              return fetchCampaign(currentBroadcast.campaignId);
+              return fetchCampaign(currentBroadcast.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -197,16 +197,16 @@ router.post('/', (req, res) => {
                 const err = new NotFoundError(`keyword ${scope.keyword} not found`);
                 return reject(err);
               }
-              logger.debug(`found keyword:${JSON.stringify(keyword)}`);
+              logger.debug(`found keyword:${JSON.stringify(keyword.fields)}`);
 
-              if (keyword.environment !== process.env.NODE_ENV) {
+              if (keyword.fields.environment !== process.env.NODE_ENV) {
                 let msg = `mData misconfiguration: ${keyword.environment} keyword sent to`;
                 msg = `${msg} ${process.env.NODE_ENV}`;
                 const err = new Error(msg);
                 return reject(err);
               }
 
-              return fetchCampaign(keyword.campaignId);
+              return fetchCampaign(keyword.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -337,7 +337,7 @@ router.post('/', (req, res) => {
     .catch(err => {
       if (err.message === 'broadcast declined') {
         logger.info('broadcast declined');
-        let msg = scope.broadcast.declinedMessage;
+        let msg = scope.broadcast.fields.declinedMessage;
         if (!msg) {
           const logMsg = 'undefined broadcast.declinedMessage';
           logger.error(logMsg);

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -161,7 +161,7 @@ router.post('/', (req, res) => {
               logger.debug(`found broadcast:${JSON.stringify(broadcast)}`);
               currentBroadcast = broadcast;
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
-              return fetchCampaign(currentBroadcast.fields.campaignId);
+              return fetchCampaign(currentBroadcast.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -43,7 +43,7 @@ function fetchSingleEntry(query) {
         return resolve(false);
       }
 
-      return resolve(entries.items[0].fields);
+      return resolve(entries.items[0]);
     })
     .catch(error => reject(contentfulError(error)));
   });
@@ -71,7 +71,8 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
   logger.debug(`contentful.fetchKeywordsForCampaignId:${campaignId}`);
   const query = {
     content_type: 'keyword',
-    'fields.campaignId': campaignId,
+    'fields.campaign.sys.contentType.sys.id': 'campaign',
+    'fields.campaign.fields.campaignId': campaignId,
   };
 
   return client.getEntries(query)
@@ -91,7 +92,7 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
       // Remove unnecessary fields.
       const keywords = filteredItems.map((item) => {
         const entry = item.fields;
-        delete entry.campaignId;
+        delete entry.campaign;
         delete entry.environment;
 
         entry.keyword = entry.keyword.toUpperCase();


### PR DESCRIPTION
#### What's this PR do?
* Updates code per latest changes to the Gambit Contentful content structure: The `campaignId` text field has been refactored as a Object reference to a newly created `campaign` Content type.

* Refactors the `contentful` helper class to return the entire Contentful response instead of only the `fields`, since an Object reference field also contains similar `sys` and `fields` properties.

#### How should this be reviewed?
Upon deploy to Thor:
* Test passing `broadcast_id=123` and responding with both yes/no
* Test staging keywords
* Verify http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns is no longer broken

#### Any background context you want to provide?
The `campaign` content type will store chatbot message overrides, as well as the messaging to use for relative reminders.

#### Relevant tickets
#775 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Update data for Thor keywords, campaigns
- [x] Tested on staging.
- [x] Update data for Production keywords, campaigns

