### PR TITLE
Fix POST Signups

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -11,32 +11,9 @@ const Promise = require('bluebird');
 const helpers = require('../../lib/helpers');
 const contentful = require('../../lib/contentful');
 const mobilecommons = require('../../lib/mobilecommons');
+const phoenix = require('../../lib/phoenix');
 const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
-
-/**
- * Fetches Campaign object from DS API for given id.
- */
-function fetchCampaign(id) {
-  return new Promise((resolve, reject) => {
-    logger.debug(`fetchCampaign:${id}`);
-
-    if (!id) {
-      const err = new NotFoundError('Campaign id undefined');
-      return reject(err);
-    }
-
-    return app.locals.clients.phoenix.Campaigns
-      .get(id)
-      .then(campaign => resolve(campaign))
-      .catch((err) => {
-        const phoenixError = err;
-        phoenixError.message = `Phoenix: ${err.message}`;
-
-        return reject(phoenixError);
-      });
-  });
-}
 
 /**
  * Determines if given incomingMessage matches given Gambit command type.
@@ -161,7 +138,7 @@ router.post('/', (req, res) => {
               logger.debug(`found broadcast:${JSON.stringify(broadcast)}`);
               currentBroadcast = broadcast;
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
-              return fetchCampaign(currentBroadcast.fields.campaign.fields.campaignId);
+              return phoenix.fetchCampaign(currentBroadcast.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -206,7 +183,7 @@ router.post('/', (req, res) => {
                 return reject(err);
               }
 
-              return fetchCampaign(keyword.fields.campaign.fields.campaignId);
+              return phoenix.fetchCampaign(keyword.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -231,7 +208,7 @@ router.post('/', (req, res) => {
 
         // If we've made it this far, check for User's current_campaign.
         logger.debug(`user.current_campaign:${user.current_campaign}`);
-        return fetchCampaign(user.current_campaign)
+        return phoenix.fetchCampaign(user.current_campaign)
           .then((campaign) => {
             if (!campaign.id) {
               // TODO: Send to non-existent start menu to select a campaign.

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -44,12 +44,12 @@ router.post('/', (req, res) => {
       return phoenix.fetchCampaign(signup.campaign);
     })
     .then((phoenixCampaign) => {
-      if (!phoenixCampaign) {
-        const msg = `Campaign ${scope.signup.campaign} is not running on CampaignBot.`;
+      if (!helpers.isCampaignBotCampaign(phoenixCampaign.id)) {
+        const msg = `Campaign ${phoenixCampaign.id} is not running on CampaignBot.`;
         throw new UnprocessibleEntityError(msg);
       }
       if (phoenixCampaign.status === 'closed') {
-        const msg = `Campaign ${scope.signup.campaign} is closed on CampaignBot.`;
+        const msg = `Campaign ${phoenixCampaign.id} is closed.`;
         throw new UnprocessibleEntityError(msg);
       }
       scope.campaign = phoenixCampaign;

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const PhoenixClient = require('@dosomething/phoenix-js');
+const NotFoundError = require('../app/exceptions/NotFoundError');
+const logger = app.locals.logger;
+
+/**
+ * Setup.
+ */
+let client;
+try {
+  client = new PhoenixClient({
+    baseURI: process.env.DS_PHOENIX_API_BASEURI,
+    username: process.env.DS_PHOENIX_API_USERNAME,
+    password: process.env.DS_PHOENIX_API_PASSWORD,
+  });
+} catch (err) {
+  logger.error(`phoenix error:${err.message}`);
+}
+
+/**
+ * Fetches Campaign object from DS API for given id.
+ */
+module.exports.fetchCampaign = function (campaignId) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`phoenix.fetchCampaign:${campaignId}`);
+
+    if (!campaignId) {
+      const err = new NotFoundError('Campaign id undefined');
+      return reject(err);
+    }
+
+    return client.Campaigns.get(campaignId)
+      .then(campaign => resolve(campaign))
+      .catch((err) => {
+        const phoenixError = err;
+        phoenixError.message = `Phoenix: ${err.message}`;
+
+        return reject(phoenixError);
+      });
+  });
+};


### PR DESCRIPTION
#### What's this PR do?
* Unborks the POST Signups endpoint by fetching the given Signup's Campaign from the DS API
* Adds a `lib/phoenix` helper class to DRY calls to `fetchCampaign`

#### How should this be reviewed?
**POST** `/v1/signups` with these scenarios:
* Signup ID belongs to an active Campaign running on CampaignBot
* Signup ID belongs to an closed Campaign running on CampaignBot
* Signup ID belongs to a Campaign not running on CampaignBot
* Signup ID doesn't exist in DS API

#### Any background context you want to provide?
There will be some upcoming DRY cleanup to do in our model classes to deprecate `app.locals.clients.phoenix`, but merging this branch for now to unbork `develop` and `master`, and help keep this PR readable.

#### Relevant tickets
#775 

#### Checklist
- [x] Tested on staging.

