### PR TITLE
Deprecate app.locals.clients

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -6,6 +6,7 @@
 const mongoose = require('mongoose');
 const logger = app.locals.logger;
 const helpers = require('../../lib/helpers');
+const phoenix = require('../../lib/phoenix');
 const MessagingGroups = require('../../lib/groups');
 
 const campaignSchema = new mongoose.Schema({
@@ -63,8 +64,7 @@ campaignSchema.statics.lookupByIDs = function (campaignIDs) {
 
     const promises = [];
 
-    return app.locals.clients.phoenix.Campaigns
-      .index({ ids: campaignIDs })
+    return phoenix.Campaigns.index({ ids: campaignIDs })
       .then((phoenixCampaigns) => {
         phoenixCampaigns.forEach((phoenixCampaign) => {
           const data = parsePhoenixCampaign(phoenixCampaign);

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -56,15 +56,15 @@ function parsePhoenixCampaign(phoenixCampaign) {
 /**
  * Get given Campaigns from DS API then store.
  */
-campaignSchema.statics.lookupByIDs = function (campaignIDs) {
+campaignSchema.statics.lookupByIds = function (campaignIds) {
   const model = this;
 
   return new Promise((resolve, reject) => {
-    logger.debug(`Campaign.lookupByIDs:${campaignIDs}`);
+    logger.debug(`Campaign.lookupByIds:${campaignIds}`);
 
     const promises = [];
 
-    return phoenix.Campaigns.index({ ids: campaignIDs })
+    return phoenix.Campaigns.index({ ids: campaignIds })
       .then((phoenixCampaigns) => {
         phoenixCampaigns.forEach((phoenixCampaign) => {
           const data = parsePhoenixCampaign(phoenixCampaign);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -6,6 +6,7 @@
 const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const NotFoundError = require('../exceptions/NotFoundError');
+const northstar = require('../../lib/northstar');
 const phoenix = require('../../lib/phoenix');
 const logger = app.locals.logger;
 
@@ -37,6 +38,7 @@ const signupSchema = new mongoose.Schema({
   // any existing or updates to Reportbacks for this Signup.
   total_quantity_submitted: Number,
   broadcast_id: Number,
+
 });
 
 function parseNorthstarSignup(northstarSignup) {
@@ -68,8 +70,7 @@ signupSchema.statics.lookupById = function (id) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupById:${id}`);
 
-    return app.locals.clients.northstar
-      .Signups.get(id)
+    return northstar.Signups.get(id)
       .then((northstarSignup) => {
         app.locals.stathat(`${statName} 200`);
         logger.debug(`northstar.Signups.get:${id} success`);
@@ -105,8 +106,7 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupCurrent(${user._id}, ${campaign.id})`);
 
-    return app.locals.clients.northstar
-      .Signups.index({ user: user._id, campaigns: campaign.id })
+    return northstar.Signups.index({ user: user._id, campaigns: campaign.id })
       .then((northstarSignups) => {
         app.locals.stathat(`${statName} 200`);
 

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -6,6 +6,7 @@
 const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const NotFoundError = require('../exceptions/NotFoundError');
+const phoenix = require('../../lib/phoenix');
 const logger = app.locals.logger;
 
 const postSource = process.env.DS_API_POST_SOURCE || 'sms-mobilecommons';
@@ -147,12 +148,12 @@ signupSchema.statics.post = function (user, campaign, keyword) {
 
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.post(${user._id}, ${campaign.id}, ${keyword})`);
+    const postData = {
+      source: postSource,
+      uid: user.phoenix_id,
+    };
 
-    return app.locals.clients.phoenix.Campaigns
-      .signup(campaign.id, {
-        source: postSource,
-        uid: user.phoenix_id,
-      })
+    return phoenix.Campaigns.signup(campaign.id, postData)
       .then((signupId) => {
         app.locals.stathat(`${statName} 200`);
         app.locals.stathat(`signup: ${keyword}`);
@@ -231,8 +232,7 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
     }
     logger.debug(`Signup.postDraftReportbackSubmission data:${JSON.stringify(data)}`);
 
-    return app.locals.clients.phoenix.Campaigns
-      .reportback(signup.campaign, data)
+    return phoenix.Campaigns.reportback(signup.campaign, data)
       .then((reportbackId) => {
         app.locals.stathat(`${statName} 200`);
         logger.info(`phoenix.Campaigns.reportback:${reportbackId}`);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -6,6 +6,7 @@
 const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const NotFoundError = require('../exceptions/NotFoundError');
+const helpers = require('../../lib/helpers');
 const northstar = require('../../lib/northstar');
 const phoenix = require('../../lib/phoenix');
 const logger = app.locals.logger;
@@ -76,11 +77,9 @@ signupSchema.statics.lookupById = function (id) {
         logger.debug(`northstar.Signups.get:${id} success`);
         const data = parseNorthstarSignup(northstarSignup);
 
-        return model.findOneAndUpdate({ _id: id }, data, { upsert: true, new: true })
-          .exec()
-          .then(signup => resolve(signup))
-          .catch(error => reject(error));
+        return model.findOneAndUpdate({ _id: id }, data, helpers.upsertOptions()).exec();
       })
+      .then(signupDoc => resolve(signupDoc))
       .catch(err => {
         app.locals.stathatError(statName, err);
         if (err.status === 404) {
@@ -121,13 +120,12 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
 
         const data = parseNorthstarSignup(currentSignup);
 
-        return model.findOneAndUpdate({ _id: data._id }, data, { upsert: true, new: true })
+        return model.findOneAndUpdate({ _id: data._id }, data, helpers.upsertOptions())
           .populate('user')
           .populate('draft_reportback_submission')
-          .exec()
-          .then(signup => resolve(signup))
-          .catch(error => reject(error));
+          .exec();
       })
+      .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
         app.locals.stathatError(statName, err);
 
@@ -165,11 +163,9 @@ signupSchema.statics.post = function (user, campaign, keyword) {
           keyword,
         };
 
-        return model.findOneAndUpdate({ _id: signupId }, data, { upsert: true, new: true })
-          .exec()
-          .then(signup => resolve(signup))
-          .catch(error => reject(error));
+        return model.findOneAndUpdate({ _id: signupId }, data, helpers.upsertOptions()).exec();
       })
+      .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
         app.locals.stathatError(statName, err);
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -60,12 +60,12 @@ userSchema.statics.lookup = function (type, id) {
       .then((northstarUser) => {
         app.locals.stathat(`${statName} 200`);
         logger.debug('northstar.Users.lookup success');
-        const data = parseNorthstarUser(northstarUser);
-        const query = { _id: data._id };
+        const userData = parseNorthstarUser(northstarUser);
+        const query = { _id: userData._id };
 
-        return model.findOneAndUpdate(query, data, helpers.upsertOptions()).exec();
+        return model.findOneAndUpdate(query, userData, helpers.upsertOptions()).exec();
       })
-      .then(user => resolve(user))
+      .then(userDoc => resolve(userDoc))
       .catch((error) => {
         app.locals.stathatError(statName, error);
 
@@ -95,11 +95,11 @@ userSchema.statics.post = function (data) {
         app.locals.stathat(`${statName} 200`);
         logger.info(`northstar.Users created user:${northstarUser.id}`);
         const query = { _id: northstarUser.id };
-        const postData = parseNorthstarUser(northstarUser);
+        const userData = parseNorthstarUser(northstarUser);
 
-        return model.findOneAndUpdate(query, postData, helpers.upsertOptions()).exec();
+        return model.findOneAndUpdate(query, userData, helpers.upsertOptions()).exec();
       })
-      .then(user => resolve(user))
+      .then(userDoc => resolve(userDoc))
       .catch((error) => {
         app.locals.stathatError(statName, error);
 

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -46,12 +46,6 @@ function parseNorthstarUser(northstarUser) {
   return data;
 }
 
-// Used in calls to findOneAndUpdate.
-const findOptions = {
-  upsert: true,
-  new: true,
-};
-
 /**
  * Query DS API for given User type/id and store.
  */
@@ -69,7 +63,7 @@ userSchema.statics.lookup = function (type, id) {
         const data = parseNorthstarUser(northstarUser);
         const query = { _id: data._id };
 
-        return model.findOneAndUpdate(query, data, findOptions).exec();
+        return model.findOneAndUpdate(query, data, helpers.upsertOptions()).exec();
       })
       .then(user => resolve(user))
       .catch((error) => {
@@ -101,8 +95,9 @@ userSchema.statics.post = function (data) {
         app.locals.stathat(`${statName} 200`);
         logger.info(`northstar.Users created user:${northstarUser.id}`);
         const query = { _id: northstarUser.id };
+        const postData = parseNorthstarUser(northstarUser);
 
-        return model.findOneAndUpdate(query, parseNorthstarUser(northstarUser), findOptions).exec();
+        return model.findOneAndUpdate(query, postData, helpers.upsertOptions()).exec();
       })
       .then(user => resolve(user))
       .catch((error) => {

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -138,7 +138,7 @@ router.post('/', (req, res) => {
               logger.debug(`found broadcast:${JSON.stringify(broadcast)}`);
               currentBroadcast = broadcast;
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
-              return phoenix.fetchCampaign(currentBroadcast.fields.campaign.fields.campaignId);
+              return phoenix.Campaigns.get(currentBroadcast.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -183,7 +183,7 @@ router.post('/', (req, res) => {
                 return reject(err);
               }
 
-              return phoenix.fetchCampaign(keyword.fields.campaign.fields.campaignId);
+              return phoenix.Campaigns.get(keyword.fields.campaign.fields.campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -208,7 +208,7 @@ router.post('/', (req, res) => {
 
         // If we've made it this far, check for User's current_campaign.
         logger.debug(`user.current_campaign:${user.current_campaign}`);
-        return phoenix.fetchCampaign(user.current_campaign)
+        return phoenix.Campaigns.get(user.current_campaign)
           .then((campaign) => {
             if (!campaign.id) {
               // TODO: Send to non-existent start menu to select a campaign.

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -41,7 +41,7 @@ router.post('/', (req, res) => {
     .then((signup) => {
       scope.signup = signup;
 
-      return phoenix.fetchCampaign(signup.campaign);
+      return phoenix.Campaigns.get(signup.campaign);
     })
     .then((phoenixCampaign) => {
       if (!helpers.isCampaignBotCampaign(phoenixCampaign.id)) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -99,3 +99,15 @@ module.exports.sendResponse = function (res, code, message) {
 
   return res.status(code).send(response);
 };
+
+/**
+ * Returns object of options to pass to mongoose.findOneAndUpdate to upsert a document.
+ */
+module.exports.upsertOptions = function () {
+  const options = {
+    upsert: true,
+    new: true,
+  };
+
+  return options;
+};

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Imports.
+ */
+const NorthstarClient = require('@dosomething/northstar-js');
+const logger = app.locals.logger;
+
+/**
+ * Setup.
+ */
+let client;
+try {
+  client = new NorthstarClient({
+    baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
+    apiKey: process.env.DS_NORTHSTAR_API_KEY,
+  });
+} catch (err) {
+  logger.error(`northstar error:${err.message}`);
+}
+
+module.exports = client;

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -4,7 +4,6 @@
  * Imports.
  */
 const PhoenixClient = require('@dosomething/phoenix-js');
-const NotFoundError = require('../app/exceptions/NotFoundError');
 const logger = app.locals.logger;
 
 /**
@@ -21,25 +20,4 @@ try {
   logger.error(`phoenix error:${err.message}`);
 }
 
-/**
- * Fetches Campaign object from DS API for given id.
- */
-module.exports.fetchCampaign = function (campaignId) {
-  return new Promise((resolve, reject) => {
-    logger.debug(`phoenix.fetchCampaign:${campaignId}`);
-
-    if (!campaignId) {
-      const err = new NotFoundError('Campaign id undefined');
-      return reject(err);
-    }
-
-    return client.Campaigns.get(campaignId)
-      .then(campaign => resolve(campaign))
-      .catch((err) => {
-        const phoenixError = err;
-        phoenixError.message = `Phoenix: ${err.message}`;
-
-        return reject(phoenixError);
-      });
-  });
-};
+module.exports = client;

--- a/server.js
+++ b/server.js
@@ -96,22 +96,6 @@ mongoose.Promise = global.Promise;
 const conn = mongoose.createConnection(DB_URI);
 app.locals.db = loader.getModels(conn);
 
-/**
- * Load clients.
- */
-app.locals.clients = {};
-
-const NorthstarClient = require('@dosomething/northstar-js');
-app.locals.clients.northstar = new NorthstarClient({
-  baseURI: process.env.DS_NORTHSTAR_API_BASEURI,
-  apiKey: process.env.DS_NORTHSTAR_API_KEY,
-});
-
-if (!app.locals.clients.northstar) {
-  logger.error('app.locals.clients.northstar undefined');
-  process.exit(1);
-}
-
 conn.on('connected', () => {
   logger.info(`conn.readyState:${conn.readyState}`);
 

--- a/server.js
+++ b/server.js
@@ -104,9 +104,9 @@ conn.on('connected', () => {
    */
   app.locals.campaigns = {};
   const loadCampaigns = app.locals.db.campaigns
-    .lookupByIDs(process.env.CAMPAIGNBOT_CAMPAIGNS)
+    .lookupByIds(process.env.CAMPAIGNBOT_CAMPAIGNS)
     .then((campaigns) => {
-      logger.debug(`app.locals.db.campaigns.lookupByIDs found ${campaigns.length} campaigns`);
+      logger.debug(`app.locals.db.campaigns.lookupByIds found ${campaigns.length} campaigns`);
 
       return campaigns.forEach((campaign) => {
         const campaignId = campaign._id;

--- a/server.js
+++ b/server.js
@@ -112,19 +112,6 @@ if (!app.locals.clients.northstar) {
   process.exit(1);
 }
 
-const PhoenixClient = require('@dosomething/phoenix-js');
-app.locals.clients.phoenix = new PhoenixClient({
-  baseURI: process.env.DS_PHOENIX_API_BASEURI,
-  username: process.env.DS_PHOENIX_API_USERNAME,
-  password: process.env.DS_PHOENIX_API_PASSWORD,
-});
-
-if (!app.locals.clients.phoenix) {
-  logger.error('app.locals.clients.phoenix undefined');
-  process.exit(1);
-}
-
-
 conn.on('connected', () => {
   logger.info(`conn.readyState:${conn.readyState}`);
 


### PR DESCRIPTION
#### What's this PR do?
* Adds `lib/phoenix` and `lib/northstar` and deprecates use of the `app.locals.clients`
* Deprecates wrapper `phoenix.fetchCampaign(id)` introduced in #786 in favor of directly calling Phoenix JS `Campaigns.get(id)`
* Cleans up nested `then.().catch()` in model functions

#### How should this be reviewed?
Full test of account creation, campaign signup, campaign reportback.

#### Any background context you want to provide?
Looking to additionally deprecate `app.locals.logger`, `app.locals.stathat`, `app.locals.db` in the same way. 

#### Relevant tickets
Refs @deadlybutter's suggestion in https://trello.com/c/H3nZ2UiA to deprecate usage of `app.locals`

#### Checklist
- [x] Tested on staging.

