### PR TITLE
Source Relative Reminder Message copy from Contentful

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -134,13 +134,6 @@ class CampaignBotController {
   }
 
   /**
-   * Wrapper function for logger.error(error)
-   */
-  error(req, err) {
-    logger.error(`${this.loggerPrefix(req)} ${err}:${err.stack}`);
-  }
-
-  /**
    * Returns whether current user has submitted a Reportback for the current campaign.
    * @param {object} req
    * @return {bool}
@@ -181,7 +174,12 @@ class CampaignBotController {
     return req.signup
       .postDraftReportbackSubmission()
       .then(() => 'menu_completed')
-      .catch(err => this.error(req, `postReportback ${err}`));
+      .catch((err) => {
+        const scope = err;
+        scope.message = `postReportback error:${err.message}`;
+
+        return scope;
+      });
   }
 
 }

--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -4,7 +4,6 @@
  * Imports.
  */
 const logger = app.locals.logger;
-const campaignBot = app.locals.campaignBot;
 const helpers = rootRequire('lib/helpers');
 
 /**
@@ -24,9 +23,10 @@ class CampaignBotController {
    */
   collectReportbackProperty(req, property, ask) {
     this.debug(req, `collectReportbackProperty:${property}`);
+    const msgType = `ask_${property}`;
 
     if (ask || req.keyword) {
-      return campaignBot.renderMessage(req, `ask_${property}`);
+      return msgType;
     }
 
     // Begin validation.
@@ -35,23 +35,22 @@ class CampaignBotController {
     // TODO: Improve quantity check by looking for commas: @see gambit issue#608
     // Search string for numbers to accept values like "Around 100" or "60 bumble bands"
     const validQuantity = Number(input) && !helpers.hasLetters(input);
-    const validTextProperty = input.length > 3 && helpers.hasLetters(input);
+    const validTextProperty = input && input.length > 3 && helpers.hasLetters(input);
 
     if (property === 'quantity') {
       if (!validQuantity) {
-        return campaignBot.renderMessage(req, 'invalid_quantity');
+        return 'invalid_quantity';
       }
       input = Number(input);
     } else if (property === 'photo') {
       input = req.incoming_image_url;
       if (!input) {
-        return campaignBot.renderMessage(req, 'no_photo_sent');
+        return 'no_photo_sent';
       }
     } else if (!validTextProperty) {
       logger.debug(`invalid ${property} sent`);
-      const prefix = 'Sorry, I didn\'t understand that.\n\n';
 
-      return campaignBot.renderMessage(req, `ask_${property}`, prefix);
+      return `invalid_${property}`;
     }
 
     const submission = req.signup.draft_reportback_submission;
@@ -63,12 +62,12 @@ class CampaignBotController {
         this.debug(req, `saved ${property}:${input}`);
 
         if (property === 'quantity') {
-          return campaignBot.renderMessage(req, 'ask_photo');
+          return 'ask_photo';
         } else if (property === 'photo') {
-          return campaignBot.renderMessage(req, 'ask_caption');
+          return 'ask_caption';
         } else if (property === 'caption') {
           if (!this.hasReportedBack(req)) {
-            return campaignBot.renderMessage(req, 'ask_why_participated');
+            return 'ask_why_participated';
           }
         }
 
@@ -181,7 +180,7 @@ class CampaignBotController {
 
     return req.signup
       .postDraftReportbackSubmission()
-      .then(() => campaignBot.renderMessage(req, 'menu_completed'))
+      .then(() => 'menu_completed')
       .catch(err => this.error(req, `postReportback ${err}`));
   }
 

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -31,12 +31,6 @@ const campaignSchema = new mongoose.Schema({
   msg_menu_signedup_gambit: String,
   msg_no_photo_sent: String,
 
-  // Exposed messages.
-  messages: {
-    scheduled_relative_to_signup_date: String,
-    scheduled_relative_to_reportback_date: String,
-  },
-
   // Mobile Commons Specific Fields.
   mobilecommons_group_doing: Number,
   mobilecommons_group_completed: Number,
@@ -112,7 +106,6 @@ campaignSchema.methods.formatApiResponse = function () {
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,
     mobilecommons_group_completed: this.mobilecommons_group_completed,
-    messages: this.messages,
     overrides: {},
   };
 

--- a/app/models/CampaignBot.js
+++ b/app/models/CampaignBot.js
@@ -6,6 +6,7 @@
 const mongoose = require('mongoose');
 const Promise = require('bluebird');
 const gambitJunior = rootRequire('lib/junior');
+const helpers = require('../../lib/helpers');
 const logger = app.locals.logger;
 const stathat = app.locals.stathat;
 
@@ -87,15 +88,7 @@ campaignBotSchema.methods.renderMessage = function (req, msgType, prefix) {
     msg = `${prefix}${msg}`;
   }
 
-  msg = msg.replace(/{{br}}/gi, '\n');
-  msg = msg.replace(/{{title}}/gi, campaign.title);
-  msg = msg.replace(/{{tagline}}/i, campaign.tagline);
-  msg = msg.replace(/{{fact_problem}}/gi, campaign.facts.problem);
-  msg = msg.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
-  msg = msg.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
-  msg = msg.replace(/{{rb_confirmation_msg}}/i, campaign.reportbackInfo.confirmationMessage);
-  msg = msg.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
-  msg = msg.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+  msg = helpers.replacePhoenixCampaignVars(msg, campaign);
 
   if (msg.indexOf('{{keyword}}') !== -1) {
     // TODO: Hack for now, we'll need to set up a MENU keyword in Mobile Commons to select Cmapaign.

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -251,9 +251,6 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
         return resolve(signup);
       })
       .catch((err) => {
-        app.locals.stathatError(statName, err);
-        logger.error(err.message);
-
         submission.failed_at = dateSubmitted;
         submission.save();
 

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -117,7 +117,7 @@ router.post('/:id/message', (req, res) => {
           return reject(err);
         }
 
-        return contentful.fetchMessageForPhoenixCampaign(phoenixCampaign, type);
+        return contentful.renderMessageForPhoenixCampaign(phoenixCampaign, type);
       })
       .then(message => resolve(message))
       .catch(err => reject(err));

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -315,14 +315,14 @@ router.post('/', (req, res) => {
       return scope.user.save();
     })
     .then(() => {
-      // TODO: Bring back to life
-      // app.locals.db.bot_requests.log(req, 'campaignbot', this._id, msgType, msg);
-
       logger.debug(`saved user.current_campaign:${scope.campaign.id}`);
       scope.user.postMobileCommonsProfileUpdate(scope.oip, scope.response_message);
 
-      return helpers.sendResponse(res, 200, scope.response_message);
+      helpers.sendResponse(res, 200, scope.response_message);
+      return app.locals.db.bot_requests
+        .log(req, 'campaignbot', campaignBot.id, scope.msg_type, scope.response_message);
     })
+    .then(botRequest => logger.debug(`created botRequest:${botRequest._id}`))
     .catch(NotFoundError, (err) => {
       logger.error(err.message);
 

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -62,15 +62,14 @@ router.post('/', (req, res) => {
       }
       scope.user = user;
 
-      const campaignBot = app.locals.campaignBot;
-      scope.response_message = campaignBot.renderMessage(scope, 'menu_signedup_external');
-
-      // Technically we don't want to ovewrite current_campaign until we know the Mobile Commons
-      // message was delivered.. but responding to the message won't work correctly without
-      // ensuring the current_campaign is set for our signup campaign. The ol' chicken and egg.
+      return app.locals.campaignBot.renderMessage(scope, 'menu_signedup_external');
+    })
+    .then((messageBody) => {
+      scope.response_message = messageBody;
       // Set current_campaign first and assume user isn't in the middle of a chatbot conversation
       // for a different campaign.
-      scope.user.current_campaign = scope.campaign._id;
+      // TODO: Refactor to set current_campaign upon user.postMobileCommonsProfileUpdate success.
+      scope.user.current_campaign = scope.campaign.id;
 
       return scope.user.save();
     })

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -4,6 +4,7 @@
  * Imports.
  */
 const contentful = require('contentful');
+const helpers = require('./helpers');
 const logger = app.locals.logger;
 
 /**
@@ -111,4 +112,31 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
       return keywords;
     })
     .catch(error => contentfulError(error));
+};
+
+module.exports.fetchMessageForPhoenixCampaign = function (phoenixCampaign, msgType) {
+  let fieldName = msgType;
+  // Values sent by Quicksilver:
+  if (msgType === 'scheduled_relative_to_signup_date') {
+    fieldName = 'scheduledRelativeToSignupDateMessage';
+  } else if (msgType === 'scheduled_relative_to_reportback_date') {
+    fieldName = 'scheduledRelativeToReportbackDateMessage';
+  }
+
+  return new Promise((resolve, reject) => {
+    const defaultCampaignId = 'default';
+    let message;
+
+    // TODO: First check if we have an override defined on the entry for our phoenixCampaign.id
+    return this.fetchCampaign(defaultCampaignId)
+      .then((contentfulCampaign) => {
+        logger.debug(`found contentfulCampaign:${defaultCampaignId}`);
+
+        message = contentfulCampaign.fields[fieldName];
+        message = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
+
+        return resolve(message);
+      })
+      .catch(err => reject(err));
+  });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -114,7 +114,12 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
     .catch(error => contentfulError(error));
 };
 
-module.exports.fetchMessageForPhoenixCampaign = function (phoenixCampaign, msgType) {
+/**
+ * Returns given msgType value saved for given campaignId.
+ */
+module.exports.fetchMessageForCampaignId = function (campaignId, msgType) {
+  logger.debug(`fetchMessageForCampaignId:${campaignId} msgType:${msgType}`);
+
   let fieldName = msgType;
   // Values sent by Quicksilver:
   if (msgType === 'scheduled_relative_to_signup_date') {
@@ -123,19 +128,42 @@ module.exports.fetchMessageForPhoenixCampaign = function (phoenixCampaign, msgTy
     fieldName = 'scheduledRelativeToReportbackDateMessage';
   }
 
+  return this.fetchCampaign(campaignId)
+    .then((contentfulCampaign) => {
+      if (!contentfulCampaign) {
+        logger.debug(`Contentful campaign not found for campaignId:${campaignId}`);
+        return null;
+      }
+
+      const message = contentfulCampaign.fields[fieldName];
+      logger.debug(`campaignId:${campaignId} msgType:${message}`);
+
+      return message;
+    })
+    .catch(err => err);
+};
+
+/**
+ * Renders given msgType for given phoenixCampaign. Checks for overrides, or sends default message.
+ */
+module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgType) {
+  logger.debug(`renderMessageForPhoenixCampaign:${phoenixCampaign.id} msgType:${msgType}`);
+
   return new Promise((resolve, reject) => {
-    const defaultCampaignId = 'default';
-    let message;
+    const defaultCampaignId = process.env.CONTENTFUL_DEFAULT_CAMPAIGN_ID || 'default';
 
-    // TODO: First check if we have an override defined on the entry for our phoenixCampaign.id
-    return this.fetchCampaign(defaultCampaignId)
-      .then((contentfulCampaign) => {
-        logger.debug(`found contentfulCampaign:${defaultCampaignId}`);
+    return this.fetchMessageForCampaignId(phoenixCampaign.id, msgType)
+      .then((message) => {
+        if (message) {
+          return message;
+        }
 
-        message = contentfulCampaign.fields[fieldName];
-        message = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
+        return this.fetchMessageForCampaignId(defaultCampaignId, msgType);
+      })
+      .then((message) => {
+        const renderedMessage = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
 
-        return resolve(message);
+        return resolve(renderedMessage);
       })
       .catch(err => reject(err));
   });

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -161,6 +161,10 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
         return this.fetchMessageForCampaignId(defaultCampaignId, msgType);
       })
       .then((message) => {
+        if (!message) {
+          const err = new Error(`Contentful cannot find message for msgType:${msgType}`);
+          return reject(err);
+        }
         const renderedMessage = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
 
         return resolve(renderedMessage);

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -165,10 +165,10 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
           const err = new Error(`Contentful cannot find message for msgType:${msgType}`);
           return reject(err);
         }
-        const renderedMessage = helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
 
-        return resolve(renderedMessage);
+        return helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
       })
+      .then(renderedMessage => resolve(renderedMessage))
       .catch(err => reject(err));
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -58,6 +58,15 @@ module.exports.fetchBroadcast = function (broadcastId) {
   });
 };
 
+module.exports.fetchCampaign = function (campaignId) {
+  logger.debug(`contentful.fetchCampaign:${campaignId}`);
+
+  return fetchSingleEntry({
+    content_type: 'campaign',
+    'fields.campaignId': campaignId,
+  });
+};
+
 module.exports.fetchKeyword = function (keyword) {
   logger.debug(`contentful.fetchKeyword:${keyword}`);
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -81,6 +81,20 @@ module.exports.generatePassword = function (text) {
     .substring(0, 6);
 };
 
+module.exports.replacePhoenixCampaignVars = function (input, campaign) {
+  let scope = input;
+  scope = scope.replace(/{{title}}/gi, campaign.title);
+  scope = scope.replace(/{{tagline}}/i, campaign.tagline);
+  scope = scope.replace(/{{fact_problem}}/gi, campaign.facts.problem);
+  scope = scope.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
+  scope = scope.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
+  scope = scope.replace(/{{rb_confirmation_msg}}/i, campaign.reportbackInfo.confirmationMessage);
+  scope = scope.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
+  scope = scope.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+
+  return scope;
+};
+
 /**
  * Formats given Express response and sends an object including given message, with given code.
  * @param {object} res - Express response

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,7 @@
  */
 const crypto = require('crypto');
 const logger = app.locals.logger;
+const contentful = require('./contentful');
 
 /**
  * Helper functions.
@@ -81,18 +82,47 @@ module.exports.generatePassword = function (text) {
     .substring(0, 6);
 };
 
-module.exports.replacePhoenixCampaignVars = function (input, campaign) {
-  let scope = input;
-  scope = scope.replace(/{{title}}/gi, campaign.title);
-  scope = scope.replace(/{{tagline}}/i, campaign.tagline);
-  scope = scope.replace(/{{fact_problem}}/gi, campaign.facts.problem);
-  scope = scope.replace(/{{rb_noun}}/gi, campaign.reportbackInfo.noun);
-  scope = scope.replace(/{{rb_verb}}/gi, campaign.reportbackInfo.verb);
-  scope = scope.replace(/{{rb_confirmation_msg}}/i, campaign.reportbackInfo.confirmationMessage);
-  scope = scope.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
-  scope = scope.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+/**
+ * Replaces given input string with variables from given phoenixCampaign and signupKeyword.
+ */
+module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, signupKeyword) {
+  return new Promise((resolve, reject) => {
+    logger.debug(`replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
+    let scope = input;
 
-  return scope;
+    try {
+      scope = scope.replace(/{{title}}/gi, phoenixCampaign.title);
+      scope = scope.replace(/{{tagline}}/i, phoenixCampaign.tagline);
+      scope = scope.replace(/{{fact_problem}}/gi, phoenixCampaign.facts.problem);
+      const reportbackInfo = phoenixCampaign.reportbackInfo;
+      scope = scope.replace(/{{rb_noun}}/gi, reportbackInfo.noun);
+      scope = scope.replace(/{{rb_verb}}/gi, reportbackInfo.verb);
+      scope = scope.replace(/{{rb_confirmation_msg}}/i, reportbackInfo.confirmationMessage);
+      scope = scope.replace(/{{cmd_reportback}}/i, process.env.GAMBIT_CMD_REPORTBACK);
+      scope = scope.replace(/{{cmd_member_support}}/i, process.env.GAMBIT_CMD_MEMBER_SUPPORT);
+      if (scope.indexOf('{{keyword}}') === -1) {
+        return resolve(scope);
+      }
+    } catch (err) { return reject(err); }
+
+    if (signupKeyword) {
+      scope = scope.replace(/{{keyword}}/i, signupKeyword);
+      return resolve(scope);
+    }
+
+    // If we've made it this far, we need to render a keyword by finding the first keyword
+    // for the Campaign defined in Contentful.
+    return contentful.fetchKeywordsForCampaignId(phoenixCampaign.id)
+      .then((keywords) => {
+        // Note: We might want to add a "primary" boolean to denote which keyword should be used
+        // as the default keyword when there are multiple. For now, we'll return the first to KISS.
+        const keyword = keywords[0].keyword;
+        scope = scope.replace(/{{keyword}}/i, keyword);
+
+        return resolve(scope);
+      })
+      .catch(err => reject(err));
+  });
 };
 
 /**


### PR DESCRIPTION
#### What's this PR do?
* Queries the Contentful Campaign content type to source Relative Reminder content from the `scheduledRelativeToSignupDateMessage` and `scheduledRelativeToReportbackDateMessage` fields, deprecating the `messages` property on the `Campaign` model.

    * If the Contentful Campaign for a given Campaign doesn't have values set for its `scheduledRelativeToSignupDateMessage` or `scheduledRelativeToReportbackDateMessage` -- use the copy defined on the Contentful Campaign with ID `default`.

    * Supports Liquid style variables for Campaign values, e.g. `{{title}}`, `{{tagline}}`

    * Removes the Northstar query from `campaigns/:id/message` -- we already have a phone number to send the message to and we aren't looking up any Signup information, so don't need to make a NS request (refs #766)

* Adds `helpers.replacePhoenixCampaignVars` function to DRY variable replacement in the `chatbot` and `campaigns` routes


    * Returns a `Promise` -- if we get a `{{keyword}}` variable, need to query Contentful to find the given Campaign's keyword


* Refactors `CampaignBotController` functions and `chatbot` route to return a message type as a string instead of the rendered message,  in prep for a future PR that will deprecate `CampaignBot` model in favor of sourcing message content from the Contentful Campaign

* Fixes #771 by returning an error in `CampaignBotController.postReportback` and checking for it in the `chatbot` route

#### How should this be reviewed?
Full test of all endpoints that deliver messages to end users: 📲  
* [x] Chatbot - from KEYWORD Signup to Reportback
* [x] POST Signups (External Signup)
* [x] POST Campaign Message

#### Relevant tickets
Fixes #771, refs #775 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
