### PR TITLE
helpers.addSenderPrefix

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -126,12 +126,7 @@ router.post('/:id/message', (req, res) => {
 
   return loadCampaignMessage
     .then((message) => {
-      messageBody = message;
-      const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
-      if (senderPrefix) {
-        messageBody = `${senderPrefix} ${messageBody}`;
-      }
-
+      messageBody = helpers.addSenderPrefix(message);
       mobilecommons.send_message(phone, messageBody);
       const msg = `Sent message:${type} for campaign:${campaignId} to phone:${phone}`;
       logger.info(msg);

--- a/app/routes/donorschoosebot.js
+++ b/app/routes/donorschoosebot.js
@@ -25,25 +25,20 @@ function info(req, message) {
 
 /**
  * Sends response object and posts update to user's Mobile Commons Profile to send SMS message.
+ * @param {object} req - Express request
  * @param {object} res - Express response
  * @param {number} code - Response HTTP code to send
  * @param {string} msgType - The type of DonorsChooseBot message to send
- * @param {object} profileUpdate - field values to update on current User's Mobile Commons Profile
  */
 function sendResponse(req, res, code, msgType) {
   debug(req, `sendResponse:${msgType}`);
   const scope = req;
-  let responseMessage = app.locals.donorsChooseBot.renderMessage(req, msgType);
-  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
-  if (senderPrefix) {
-    responseMessage = `${senderPrefix} ${responseMessage}`;
-  }
-
-  scope.profile_update.gambit_chatbot_response = responseMessage;
+  const responseMessage = app.locals.donorsChooseBot.renderMessage(req, msgType);
+  scope.profile_update.gambit_chatbot_response = helpers.addSenderPrefix(responseMessage);
   const profile = req.body;
   mobilecommons.profile_update(profile.profile_id, profile.phone, scope.oip, scope.profile_update);
 
-  return helpers.sendResponse(res, code, responseMessage);
+  return helpers.sendResponse(res, code, scope.profile_update.gambit_chatbot_response);
 }
 
 /**

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -65,7 +65,7 @@ router.post('/', (req, res) => {
       return app.locals.campaignBot.renderMessage(scope, 'menu_signedup_external');
     })
     .then((messageBody) => {
-      scope.response_message = messageBody;
+      scope.response_message = helpers.addSenderPrefix(messageBody);
       // Set current_campaign first and assume user isn't in the middle of a chatbot conversation
       // for a different campaign.
       // TODO: Refactor to set current_campaign upon user.postMobileCommonsProfileUpdate success.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,6 +12,18 @@ const contentful = require('./contentful');
  */
 
 /**
+ * Prepends the Sender Prefix config variable if it exists.
+ */
+module.exports.addSenderPrefix = function (string) {
+  const senderPrefix = process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX;
+  if (!senderPrefix) {
+    return string;
+  }
+
+  return `${senderPrefix} ${string}`;
+};
+
+/**
  * Returns whether given Campaign id is enabled for CampaignBot.
  */
 module.exports.isCampaignBotCampaign = function (campaignId) {


### PR DESCRIPTION
#### What's this PR do?
* DRY prefixing the  `process.env.GAMBIT_CHATBOT_RESPONSE_PREFIX` variable to response messages via new `helpers.addSenderPrefix` function
* Fixes bug in #791 -- missed returning the `campaignBot.renderResponse` as a Promise for a Closed Campaign message

#### How should this be reviewed?
* Test all endpoints that send responses to end user
* Text in a keyword for a closed campaign to verify Closed Campaign message is sent

#### Any background context you want to provide?
The sender prefix setting is mostly for internal staff use. Setting the prefix as `@thor` on Thor helps us know when a message is sent from our test server, or if we happened to receive a scheduled message from production.

#### Checklist
- [x] Tested on staging.

