### PR TITLE
Return 422 error when Campaign Message type not found

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -6,6 +6,7 @@
 const contentful = require('contentful');
 const helpers = require('./helpers');
 const logger = app.locals.logger;
+const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
 
 const contentfulCampaignFields = {
   ask_caption: 'askCaptionMessage',
@@ -169,7 +170,9 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
       })
       .then((message) => {
         if (!message) {
-          const err = new Error(`Contentful cannot find message for msgType:${msgType}`);
+          const errorMsg = `Contentful msgType:${msgType} is not defined for default Campaign.`;
+          const err = new UnprocessibleEntityError(errorMsg);
+
           return reject(err);
         }
 


### PR DESCRIPTION
#### What's this PR do?
Throws an `UnprocessibleEntityError` in our `lib/contentful` if a given message type isn't defined on the default Campaign, returning a 422 instead of a 500.

#### How should this be reviewed?
**POST** /v1/campaigns/:id/message with type `scheduled_relative_to_reportback_date`

#### Any background context you want to provide?
Throwing the 500 will log these errors in New Relic. We're ignoring 422's, which seems appropriate, as we don't have a default set for the Scheduled Relative to Reportback Date message.

#### Checklist
- [x] Tested on staging.
