### PR TITLE
contentful.fetchCampaignIdsWithKeywords

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -4,6 +4,7 @@
  * Imports.
  */
 const contentful = require('contentful');
+const Promise = require('bluebird');
 const helpers = require('./helpers');
 const logger = app.locals.logger;
 const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
@@ -87,6 +88,26 @@ module.exports.fetchCampaign = function (campaignId) {
   });
 };
 
+module.exports.fetchCampaignIdsWithKeywords = function () {
+  logger.debug('contentful.fetchCampaignsWithKeywords');
+  const campaignMap = {};
+  return this.fetchKeywordsForCampaignId()
+    .then((keywords) => {
+      keywords.forEach((keyword) => {
+        const campaignId = keyword.campaign.fields.campaignId;
+        if (!campaignMap[campaignId]) {
+          campaignMap[campaignId] = true;
+        }
+      })
+      const result = Object.keys(campaignMap);
+      console.log(result);
+
+      return result;
+    })
+    .catch(err => err);
+
+};
+
 module.exports.fetchKeyword = function (keyword) {
   logger.debug(`contentful.fetchKeyword:${keyword}`);
 
@@ -102,17 +123,21 @@ module.exports.fetchKeywordsForCampaignId = function (campaignId) {
     content_type: 'keyword',
     // We store keywords for both Thor and Production as entries, so filter by current environment.
     'fields.environment': process.env.NODE_ENV,
-    'fields.campaign.sys.contentType.sys.id': 'campaign',
-    'fields.campaign.fields.campaignId': campaignId,
   };
+  if (campaignId) {
+    query['fields.campaign.sys.contentType.sys.id'] = 'campaign';
+    query['fields.campaign.fields.campaignId'] = campaignId;
+  }
 
   return client.getEntries(query)
     .then((response) => {
       // Remove unnecessary fields.
       const keywords = response.items.map((item) => {
         const entry = item.fields;
-        delete entry.campaign;
         delete entry.environment;
+        if (campaignId) {
+          delete entry.campaign;
+        }
         // Note: We return each keyword as an object, because we eventually plan to add more fields
         // to a keyword, e.g. a different greeting to send when a specific keyword is sent.
         entry.keyword = entry.keyword.toUpperCase();

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -91,21 +91,22 @@ module.exports.fetchCampaign = function (campaignId) {
 module.exports.fetchCampaignIdsWithKeywords = function () {
   logger.debug('contentful.fetchCampaignsWithKeywords');
   const campaignMap = {};
+
   return this.fetchKeywordsForCampaignId()
     .then((keywords) => {
       keywords.forEach((keyword) => {
         const campaignId = keyword.campaign.fields.campaignId;
+        if (!campaignId) {
+          return;
+        }
         if (!campaignMap[campaignId]) {
           campaignMap[campaignId] = true;
         }
-      })
-      const result = Object.keys(campaignMap);
-      console.log(result);
+      });
 
-      return result;
+      return Object.keys(campaignMap);
     })
     .catch(err => err);
-
 };
 
 module.exports.fetchKeyword = function (keyword) {


### PR DESCRIPTION
#### What's this PR do?
First steps towards deprecating the `GAMBIT_CHATBOT_CAMPAIGNS` config variable to determine what Campaigns are running on Gambit (e.g. CampaignBot campaigns). End goal is that it's determined if a Campaign is running on Gambit simply if it has a published keyword.

* Adds `contentful.fetchCampaignIdsWithKeywords` to query Contentful for a list of Campaign ID's that have published keywords

* Refactors GET campaigns to return the Campaigns found in this list
    * Deprecates `campaignbot` boolean property -- new check to see if a campaign is running on Gambit is to check for a non-empty `keywords` property
  
#### How should this be reviewed?
GET campaigns and GET campaigns/:id

#### Any background context you want to provide?
Next steps: 
* Refactor other functions that call `helpers.isCampaignBotCampaign`, and eventually deprecate that function
* Deprecate `campaigns` collection by storing Group info in Contentful

#### Relevant tickets
#775 

#### Checklist
- [x] Tested on staging.
