### PR TITLE
Check for keywords to determine if Campaign is running on Gambit

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -5,7 +5,6 @@
  */
 const mongoose = require('mongoose');
 const logger = app.locals.logger;
-const helpers = require('../../lib/helpers');
 const phoenix = require('../../lib/phoenix');
 const MessagingGroups = require('../../lib/groups');
 
@@ -81,7 +80,6 @@ campaignSchema.methods.findOrCreateMessagingGroups = function () {
 campaignSchema.methods.formatApiResponse = function () {
   const data = {
     id: this._id,
-    campaignbot: helpers.isCampaignBotCampaign(this._id),
     current_run: this.current_run,
     mobilecommons_group_doing: this.mobilecommons_group_doing,
     mobilecommons_group_completed: this.mobilecommons_group_completed,

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -46,14 +46,18 @@ router.post('/', (req, res) => {
       return phoenix.client.Campaigns.get(signup.campaign);
     })
     .then((phoenixCampaign) => {
-      if (!helpers.isCampaignBotCampaign(phoenixCampaign.id)) {
-        const msg = `Campaign ${phoenixCampaign.id} is not running on CampaignBot.`;
-        throw new UnprocessibleEntityError(msg);
-      }
       if (phoenix.isClosedCampaign(phoenixCampaign)) {
         throw new ClosedCampaignError(phoenixCampaign);
       }
       scope.campaign = phoenixCampaign;
+
+      return contentful.fetchKeywordsForCampaignId(phoenixCampaign.id);
+    })
+    .then((keywords) => {
+      if (keywords.length === 0) {
+        const msg = `Campaign ${scope.campaign.id} does not have any Gambit keywords.`;
+        throw new UnprocessibleEntityError(msg);
+      }
 
       return app.locals.db.users.lookup('id', scope.signup.user);
     })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,15 +23,6 @@ module.exports.addSenderPrefix = function (string) {
   return `${senderPrefix} ${string}`;
 };
 
-/**
- * Returns whether given Campaign id is enabled for CampaignBot.
- */
-module.exports.isCampaignBotCampaign = function (campaignId) {
-  // TODO: We'll eventually determine if a CampaignBotCampaign is enabled if it has a live keyword.
-  // @see https://github.com/DoSomething/gambit/issues/775
-  return !!app.locals.campaigns[campaignId];
-};
-
 module.exports.isValidZip = function (zip) {
   return /(^\d{5}$)|(^\d{5}-\d{4}$)/.test(zip);
 };

--- a/server.js
+++ b/server.js
@@ -102,19 +102,13 @@ conn.on('connected', () => {
   /**
    * Load campaigns.
    */
-  app.locals.campaigns = {};
   const loadCampaigns = app.locals.db.campaigns
     .lookupByIds(process.env.CAMPAIGNBOT_CAMPAIGNS)
     .then((campaigns) => {
       logger.debug(`app.locals.db.campaigns.lookupByIds found ${campaigns.length} campaigns`);
 
       return campaigns.forEach((campaign) => {
-        const campaignId = campaign._id;
-        // Eventually looking to deprecate app.locals.campaigns, leaving for now
-        // as its used by the campaigns/:id/message route.
-        app.locals.campaigns[campaignId] = campaign;
-        logger.info(`loaded app.locals.campaigns[${campaignId}]`);
-
+        logger.info(`Checking messaging groups for Campaign ${campaign._id}`);
         if (!campaign.mobilecommons_group_doing || !campaign.mobilecommons_group_completed) {
           campaign.findOrCreateMessagingGroups();
         }


### PR DESCRIPTION
#### What's this PR do?
Instead of checking for the Campaign ID in `GAMBIT_CHATBOT_CAMPAIGNS` config variable, query Contentful to see if it has any keywords to determine if its enabled on Gambit.
* Removes deprecated `helpers.isCampaignBotCampaign` function
* removes deprecated `app.locals.campaigns` object

#### How should this be reviewed?
Post to Campaign Message and Signup endpoints with Campaigns that do/don't have keywords to verify expected behavior.


#### Any background context you want to provide?
Next up is storing Messaging Group Id's in the Contentful Campaign content type instead of the `campaigns` collection, to deprecate the `Campaign` model entirely.

#### Relevant tickets
#775 

#### Checklist
- [ ] Tested on staging.
