### PR TITLE
Stathat cleanup

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -155,7 +155,9 @@ signupSchema.statics.post = function (user, campaign, keyword) {
     return phoenix.client.Campaigns.signup(campaign.id, postData)
       .then((signupId) => {
         app.locals.stathat(`${statName} 200`);
-        app.locals.stathat(`signup: ${keyword}`);
+        if (keyword) {
+          app.locals.stathat(`signup: ${keyword}`);
+        }
         logger.info(`Signup.post created signup:${signupId}`);
 
         const data = {

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -320,6 +320,7 @@ router.post('/', (req, res) => {
       logger.debug(`saved user.current_campaign:${scope.campaign.id}`);
       scope.user.postMobileCommonsProfileUpdate(scope.oip, scope.response_message);
       helpers.sendResponse(res, 200, scope.response_message);
+      stathat(`campaignbot:${scope.msg_type}`);
 
       return BotRequest.log(req, 'campaignbot', null, scope.msg_type, scope.response_message);
     })

--- a/server.js
+++ b/server.js
@@ -65,6 +65,7 @@ app.locals.stathat = function (statName) {
   }
   const appName = process.env.STATHAT_APP_NAME || 'gambit';
   const stat = `${appName} - ${statName}`;
+  logger.debug(`stathat: ${stat}`);
 
   // Bump count of stat by 1.
   stathat.trackEZCount(key, stat, 1, status => logger.verbose(`stathat:${stat} ${status}`));


### PR DESCRIPTION
#### What's this PR do?
* Adds missing `campaignbot:{message type}` stathat events to close #805 
* Adds check to only report keyword Signup when `keyword` exists to close #806 
* Adds `debug` call to `app.locals.stathat` function

#### Checklist
- [x] Tested on staging.
