### PR TITLE
Check for archived Contentful campaigns

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -3,7 +3,7 @@
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
 const Promise = require('bluebird');
-const Campaign = require('../exceptions/NotFoundError');
+const Campaign = require('../models/Campaign');
 const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
 const NotFoundError = require('../exceptions/NotFoundError');
 const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -95,6 +95,9 @@ module.exports.fetchCampaignIdsWithKeywords = function () {
   return this.fetchKeywordsForCampaignId()
     .then((keywords) => {
       keywords.forEach((keyword) => {
+        if (!keyword || !keyword.campaign.fields) {
+          return;
+        }
         const campaignId = keyword.campaign.fields.campaignId;
         if (!campaignId) {
           return;


### PR DESCRIPTION
#### What's this PR do?
Fixes GET campaigns response when a Contentful campaign has been archived, but still has a published keyword. 

#### How should this be reviewed?
GET /campaigns

#### Any background context you want to provide?
My recommendation is we always keep Campaigns in Contentful published. Regardless -- we want this check to avoid a broken response.

#### Relevant tickets
Fixes #808 

#### Checklist
- [x] Tested on staging: http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns
