### PR TITLE
Pin New Relic version to 1.37.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.10.2",
     "html-entities": "^1.1.1",
     "mongoose": "~4.6.1",
-    "newrelic": "^1.0.0",
+    "newrelic": "1.37.0",
     "node-request-retry": "^1.0.0",
     "path": "~0.4.9",
     "request": "2.34.x",


### PR DESCRIPTION
#### What's this PR do?
Pins version to 1.37.0 to try re-enabling New Relic, and avoiding #811 
