### PR TITLE
Pin Node version to 6.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   },
   "engines": {
-    "node": ">=6.10.x"
+    "node": "6.10.x"
   },
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",


### PR DESCRIPTION
#### What's this PR do?
Pins Node version to 6.10. We were previously always using the latest version of Node 🤦‍♀️ 

#### How should this be reviewed?
Deploy to heroku and confirm the build logs look like this:
````
-----> Installing binaries
       engines.node (package.json):  6.10.x
       engines.npm (package.json):   unspecified (use default)
       
       Resolving node version 6.10.x via semver.io...
       Downloading and installing node 6.10.0...
       Using default npm version: 3.10.10
-----> Restoring cache
````

Instead of this:
````
-----> Installing binaries
       engines.node (package.json):  >=6.10.x
       engines.npm (package.json):   unspecified (use default)
       
       Resolving node version >=6.10.x via semver.io...
       Downloading and installing node 7.7.2...
````

#### Any background context you want to provide?
This should close out #811 if Node 7.7.2 is the culprit as suggested in https://github.com/DoSomething/gambit/issues/811#issuecomment-285753435

#### Relevant tickets
Fixes #811 

#### Checklist
- [x] Tested on staging.
