### PR TITLE
Campaigns API: Return all rendered messages for a Campaign

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -29,20 +29,14 @@ function fetchCampaign(id) {
         campaign.title = phoenixCampaign.title;
         campaign.status = phoenixCampaign.status;
 
+        return contentful.renderAllMessagesForPhoenixCampaign(phoenixCampaign);
+      })
+      .then((renderedMessages) => {
+        campaign.messages = renderedMessages;
         return contentful.fetchKeywordsForCampaignId(id);
       })
       .then((keywords) => {
         campaign.keywords = keywords;
-
-        return contentful.fetchCampaign(id);
-      })
-      .then((contentfulCampaign) => {
-        if (contentfulCampaign) {
-          campaign.overrides = contentfulCampaign.fields;
-          delete campaign.overrides.campaignId;
-        } else {
-          campaign.overrides = {};
-        }
 
         return Campaign.findById(id).exec();
       })

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -213,7 +213,7 @@ Name | Type | Description
 <details><summary>**Example Request**</summary><p>
 
 ```
-curl http://localhost:5000/v1/campaigns/4944/message \
+curl http://localhost:5000/v1/campaigns/2900/message \
      -H "x-gambit-api-key: totallysecret" \
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \
@@ -225,7 +225,12 @@ curl http://localhost:5000/v1/campaigns/4944/message \
 <details><summary>**Example Response**</summary><p>
 
 ```
-{"success":{"code":200,"message":"Sent text for 46 scheduled_relative_to_signup_date to 5555555511"}}
+{
+  "success": {
+    "code": 200,
+    "message": "@dev: Have you completed Get Lucky yet?  \n\nIf you have created some fortune tellers, take a pic to prove it and text back LUCKYBOT"
+  }
+}
 ```
 
 </p></details>

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -1,18 +1,76 @@
 # Campaigns
 
-## Retrieve all Campaigns 
+## Retrieve Campaigns running on Gambit
 
 ```
 GET /v1/campaigns
 ```
 
-Returns index of Gambit Campaign models stored in `campaigns` collection.
+Returns index of Campaigns with published keywords.
 
-**Parameters**
-
-Name | Type | Description
---- | --- | ---
-`campaignbot` | `boolean` | If set to `true`, only return Campaigns defined in `CAMPAIGNBOT_CAMPAIGNS`
+<details>
+<summary>**Example Request**</summary>
+```
+curl http://localhost:5000/v1/campaigns \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+```
+</details>
+<details>
+<summary>**Example Response**</summary>
+````
+{
+  "data": [
+    {
+      "id": "46",
+      "title": "Don't Be a Sucker",
+      "status": "closed",
+      "keywords": [
+        {
+          "keyword": "SUCKERBOT"
+        }
+      ],
+      "current_run": 7547,
+      "mobilecommons_group_doing": 284005,
+      "mobilecommons_group_completed": 284011
+    },
+    {
+      "id": "2070",
+      "title": "Bumble Bands",
+      "status": "active",
+      "keywords": [
+        {
+          "keyword": "BUMBLEBOT"
+        },
+        {
+          "keyword": "BEESBOT"
+        }
+      ]
+    },
+    {
+      "id": "3590",
+      "title": "Shower Songs",
+      "status": "active",
+      "keywords": [
+        {
+          "keyword": "SHOWERBOT"
+        }
+      ]
+    },
+    {
+      "id": "7483",
+      "title": "Rinse, Recycle, Repeat",
+      "status": "active",
+      "keywords": [
+        {
+          "keyword": "RINSEBOT"
+        }
+      ]
+    }
+  ]
+}
+````
+</details>
 
 ## Retrieve a Campaign
 
@@ -20,7 +78,117 @@ Name | Type | Description
 GET /v1/campaigns/:id
 ```
 
-Returns a single Gambit Campaign model for given Campaign ID.
+Returns a single Campaign, and its rendered Gambit messages in a `messages` object property.
+
+The keys defined in the `messages` object correspond to fields on the Contentful Campaign content
+type, e.g `askCaptionMessage`. Each field property contains an object with properties:
+
+* `override` -- boolean specifying whether the `raw` value is defined on the entry for the
+given Campaign ID, or the default Campaign
+* `raw` -- string, the copy stored in Contentful to use for this message type
+* `rendered` -- string, the rendered copy to be delivered to the end user
+
+<details>
+<summary>**Example Request**</summary>
+```
+curl http://localhost:5000/v1/campaigns/7483 \
+     -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+```
+</details>
+<details>
+<summary>**Example Response**</summary>
+```
+{
+  "data": {
+    "id": "7483",
+    "title": "Rinse, Recycle, Repeat",
+    "status": "active",
+    "messages": {
+      "gambitSignupMenuMessage": {
+        "override": true,
+        "raw": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!",
+        "rendered": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!"
+      },
+      "externalSignupMenuMessage": {
+        "override": true,
+        "raw": "Thanks for joining {{title}}!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text {{cmd_reportback}} to share it with us!",
+        "rendered": "Thanks for joining Rinse Recycle Repeat!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text P to share it with us!"
+      },
+      "invalidSignupMenuCommandMessage": {
+        "override": false,
+        "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} when you have {{rb_verb}} some {{rb_noun}}.\n\nIf you have a question, text {{cmd_member_support}}.",
+        "rendered": "Sorry, I didn't understand that.\n\nText P when you have decorated some bins.\n\nIf you have a question, text Q."
+      },
+      "askQuantityMessage": {
+        "override": false,
+        "raw": "Sweet! First, what's the total number of {{rb_noun}} you {{rb_verb}}?\n\nSend the exact number back.",
+        "rendered": "Sweet! First, what's the total number of bins you decorated?\n\nSend the exact number back."
+      },
+      "invalidQuantityMessage": {
+        "override": false,
+        "raw": "Sorry, that's not a valid number.\n\nWhat's the total number of {{rb_noun}} you have {{rb_verb}}?\n\nIf you have a question, text {{cmd_member_support}}.",
+        "rendered": "Sorry, that's not a valid number.\n\nWhat's the total number of bins you have decorated?\n\nIf you have a question, text Q."
+      },
+      "askPhotoMessage": {
+        "override": false,
+        "raw": "Nice! Send your best pic of you and the {{quantity}} {{rb_noun}} you {{rb_verb}}.",
+        "rendered": "Nice! Send your best pic of you and the {{quantity}} bins you decorated."
+      },
+      "invalidPhotoMessage": {
+        "override": false,
+        "raw": "Sorry, I didn't get that.\n\nSend a photo of the {{rb_noun}} you have {{rb_verb}}.\n\nIf you have a question, text {{cmd_member_support}} - I'll get back to you within 24 hours.",
+        "rendered": "Sorry, I didn't get that.\n\nSend a photo of the bins you have decorated.\n\nIf you have a question, text Q - I'll get back to you within 24 hours."
+      },
+      "askCaptionMessage": {
+        "override": false,
+        "raw": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
+        "rendered": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please."
+      },
+      "askWhyParticipatedMessage": {
+        "override": false,
+        "raw": "Last question: Why was participating in {{title}} important to you? (No need to write an essay, one sentence is good).",
+        "rendered": "Last question: Why was participating in Rinse, Recycle, Repeat important to you? (No need to write an essay, one sentence is good)."
+      },
+      "completedMenuMessage": {
+        "override": false,
+        "raw": "{{rb_confirmation_msg}}\n\nWe've got you down for {{quantity}} {{rb_noun}} {{rb_verb}}.\n\nHave you {{rb_verb}} more? Text {{cmd_reportback}}",
+        "rendered": "Thanks for helping to keep #empties out of landfills! You'll receive an email shortly with a free shipping label so you can send your empties to TerraCycle be upcycled.\n\nWe've got you down for {{quantity}} bins decorated.\n\nHave you decorated more? Text P"
+      },
+      "invalidCompletedMenuCommandMessage": {
+        "override": false,
+        "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} if you have {{rb_verb}} more {{rb_noun}}.\n\nIf you have a question, text {{cmd_member_support}}.",
+        "rendered": "Sorry, I didn't understand that.\n\nText P if you have decorated more bins.\n\nIf you have a question, text Q."
+      },
+      "scheduledRelativeToSignupDateMessage": {
+        "override": true,
+        "raw": "Hey it's Freddie again! Have you had a chance to create a recycling bin?\n\nShare what you've done with other DoSomething members. Text back RINSE!",
+        "rendered": "Hey it's Freddie again! Have you had a chance to create a recycling bin?\n\nShare what you've done with other DoSomething members. Text back RINSE!"
+      },
+      "scheduledRelativeToReportbackDateMessage": {
+        "override": false,
+        "rendered": ""
+      },
+      "memberSupportMessage": {
+        "override": false,
+        "raw": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue {{title}}, text back {{keyword}}",
+        "rendered": "Text back your question and I'll try to get back to you within 24 hrs.\n\nIf you want to continue Rinse, Recycle, Repeat, text back RINSEBOT"
+      },
+      "campaignClosedMessage": {
+        "override": false,
+        "raw": "Sorry, {{title}} is no longer available.\n\nText {{cmd_member_support}} for help.",
+        "rendered": "Sorry, Rinse, Recycle, Repeat is no longer available.\n\nText Q for help."
+      }
+    },
+    "keywords": [
+      {
+        "keyword": "RINSEBOT"
+      }
+    ]
+  }
+}
+````
+</details>
 
 ## Send a campaign message
 

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -8,17 +8,19 @@ GET /v1/campaigns
 
 Returns index of Campaigns with published keywords.
 
-<details>
-<summary>**Example Request**</summary>
+<details><summary>**Example Request**</summary><p>
+
 ```
 curl http://localhost:5000/v1/campaigns \
-     -H "Accept: application/json" \
-     -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
 ```
-</details>
-<details>
-<summary>**Example Response**</summary>
-````
+
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
 {
   "data": [
     {
@@ -69,8 +71,9 @@ curl http://localhost:5000/v1/campaigns \
     }
   ]
 }
-````
-</details>
+```
+
+</p></details>
 
 ## Retrieve a Campaign
 
@@ -88,16 +91,17 @@ given Campaign ID, or the default Campaign
 * `raw` -- string, the copy stored in Contentful to use for this message type
 * `rendered` -- string, the rendered copy to be delivered to the end user
 
-<details>
-<summary>**Example Request**</summary>
+<details><summary>**Example Request**</summary><p>
+
 ```
 curl http://localhost:5000/v1/campaigns/7483 \
      -H "Accept: application/json" \
      -H "Content-Type: application/json" \
 ```
-</details>
-<details>
-<summary>**Example Response**</summary>
+
+</p></details>
+<details><summary>**Example Response**</summary><p>
+
 ```
 {
   "data": {
@@ -187,8 +191,9 @@ curl http://localhost:5000/v1/campaigns/7483 \
     ]
   }
 }
-````
-</details>
+```
+
+</p></details>
 
 ## Send a campaign message
 
@@ -205,9 +210,8 @@ Name | Type | Description
 `phone` | `string` | **Required.** Mobile number to send the campaign message.
 `type`  | `string` | <div>**Required.** The campaign message type.</div><div>Supported types are: `scheduled_relative_to_signup_date`, `scheduled_relative_to_reportback_date`</div>
 
+<details><summary>**Example Request**</summary><p>
 
-<details>
-<summary>**Example Request**</summary>
 ```
 curl http://localhost:5000/v1/campaigns/4944/message \
      -H "x-gambit-api-key: totallysecret" \
@@ -215,11 +219,13 @@ curl http://localhost:5000/v1/campaigns/4944/message \
      -H "Content-Type: application/json" \
      -d '{"phone": "5555555511", "type": "scheduled_relative_to_signup_date"}'
 ```
-</details>
 
-<details>
-<summary>**Example Response**</summary>
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
 ```
 {"success":{"code":200,"message":"Sent text for 46 scheduled_relative_to_signup_date to 5555555511"}}
 ```
-</details>
+
+</p></details>

--- a/documentation/endpoints/chatbot.md
+++ b/documentation/endpoints/chatbot.md
@@ -26,26 +26,28 @@ Name | Type | Description
 `profile_id` | `number` | Mobile Commons Profile ID
 `broadcast_id` | `number` | Mobile Commons Broadcast ID, if User is responding to a Broadcast
 
-<details>
-<summary>**Example Request**</summary>
-````
+<details><summary>**Example Request**</summary><p>
+
+```
 curl -X "POST" "http://localhost:5000/v1/chatbot" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
      --data-urlencode "phone=5555555511" \
      --data-urlencode "keyword=slothieboi"
      --data-urlencode "profile_id=136122001" \
-````
-</details>
+```
 
-<details>
-<summary>**Example Response**</summary>
-````
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
 {
   "success": {
     "code": 200,
     "message": "Picking up where you left off on Bumble Bands...\n\nSend your best pic of you and the 33 bumble bands you created."
   }
 }
-````
-</details>
+```
+
+</p></details>

--- a/documentation/endpoints/donorschoosebot.md
+++ b/documentation/endpoints/donorschoosebot.md
@@ -32,20 +32,21 @@ Name | Type | Description
 `profile_postal_code` | `string` | Mobile Commons Profile zip
 `profile_ss2016_donation_count` | `string` | Mobile Commons Custom Field to store number of donations. This parameter name can be changed via `DONORSCHOOSE_DONATION_FIELDNAME`
 
-<details>
-<summary>**Example Request**</summary>
-````
+<details><summary>**Example Request**</summary><p>
+
+```
 curl -X "POST" "http://localhost:5000/v1/donorschoosebot?start=true" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
      --data-urlencode "phone=5555555511" \
      --data-urlencode "profile_id=136122001" \
-````
-</details>
+```
 
-<details>
-<summary>**Example Response**</summary>
-````
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
 {
   "success": {
     "code": 200,
@@ -53,5 +54,6 @@ curl -X "POST" "http://localhost:5000/v1/donorschoosebot?start=true" \
   }
 }
 
-````
-</details>
+```
+
+</p></details>

--- a/documentation/endpoints/signups.md
+++ b/documentation/endpoints/signups.md
@@ -19,25 +19,27 @@ Name | Type | Description
 `id` | `number` |  **Required.**  Signup ID to update Gambit cache for
 `source` | `string` |  **Required.** Signup source -- if not equal to the `DS_API_POST_SOURCE` config var value, sends Signup confirmation message to User via chatbot
 
-<details>
-<summary>**Example Request**</summary>
-````
+<details><summary>**Example Request**</summary><p>
+
+```
 curl -X "POST" "http://localhost:5000/v1/signups" \
      -H "x-gambit-api-key: totallysecret" \
      -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
      --data-urlencode "id=2309235" \
      --data-urlencode "source=slothbot-app-v0.2.1" \
-````
-</details>
+```
 
-<details>
-<summary>**Example Response**</summary>
-````
+</p></details>
+
+<details><summary>**Example Response**</summary><p>
+
+```
 {
   "success": {
     "code": 200,
     "message":  "Hey, it's Puppet Sloth. Thanks for joining Aging Former YouTube Celebs! Text NEXTQUESTION to get started."
   }
 }
-````
-</details>
+```
+
+</p></details>

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -218,6 +218,7 @@ module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) 
   logger.debug(`renderAllMessagesForPhoenixCampaign:${phoenixCampaign.id}`);
 
   return new Promise((resolve, reject) => {
+    const campaignFieldNames = Object.keys(contentfulCampaignFields);
     const campaignContent = {};
     const result = {};
 
@@ -229,8 +230,9 @@ module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) 
       })
       .then((defaultContentfulCampaign) => {
         campaignContent.defaults = defaultContentfulCampaign.fields;
+        const promises = [];
 
-        Object.keys(contentfulCampaignFields).forEach((key) => {
+        campaignFieldNames.forEach((key) => {
           const fieldName = contentfulCampaignFields[key];
           result[fieldName] = {};
 
@@ -240,6 +242,23 @@ module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) 
           } else {
             result[fieldName].override = false;
             result[fieldName].raw = campaignContent.defaults[fieldName];
+          }
+
+          promises.push(helpers.replacePhoenixCampaignVars(result[fieldName].raw, phoenixCampaign));
+        });
+
+        return Promise.all(promises);
+      })
+      .then((renderedMessages) => {
+        // The order of renderedMessages corresponds to the sequence we defined campaignFieldNames.
+        renderedMessages.forEach((renderedMessage, index) => {
+          // Store the machine name used in code (e.g. 'ask_caption').
+          const key = campaignFieldNames[index];
+          // Find the Contentful field name that corresponds to the machine name.
+          const fieldName = contentfulCampaignFields[key];
+
+          if (result[fieldName]) {
+            result[fieldName].rendered = renderedMessage;
           }
         });
 

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -9,6 +9,7 @@ const helpers = require('./helpers');
 const logger = app.locals.logger;
 const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
 
+const defaultCampaignId = process.env.CONTENTFUL_DEFAULT_CAMPAIGN_ID || 'default';
 const contentfulCampaignFields = {
   ask_caption: 'askCaptionMessage',
   ask_photo: 'askPhotoMessage',
@@ -187,9 +188,7 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
   logger.debug(`renderMessageForPhoenixCampaign:${phoenixCampaign.id} msgType:${msgType}`);
 
   return new Promise((resolve, reject) => {
-    const defaultCampaignId = process.env.CONTENTFUL_DEFAULT_CAMPAIGN_ID || 'default';
-
-    return this.fetchMessageForCampaignId(phoenixCampaign.id, msgType)
+    this.fetchMessageForCampaignId(phoenixCampaign.id, msgType)
       .then((message) => {
         if (message) {
           return message;
@@ -208,6 +207,44 @@ module.exports.renderMessageForPhoenixCampaign = function (phoenixCampaign, msgT
         return helpers.replacePhoenixCampaignVars(message, phoenixCampaign);
       })
       .then(renderedMessage => resolve(renderedMessage))
+      .catch(err => reject(err));
+  });
+};
+
+/**
+ * Returns all rendered messages for given phoenixCampaign, using defaults when no override defined.
+ */
+module.exports.renderAllMessagesForPhoenixCampaign = function (phoenixCampaign) {
+  logger.debug(`renderAllMessagesForPhoenixCampaign:${phoenixCampaign.id}`);
+
+  return new Promise((resolve, reject) => {
+    const campaignContent = {};
+    const result = {};
+
+    return this.fetchCampaign(phoenixCampaign.id)
+      .then((contentfulCampaign) => {
+        campaignContent.overrides = contentfulCampaign.fields;
+
+        return this.fetchCampaign(defaultCampaignId);
+      })
+      .then((defaultContentfulCampaign) => {
+        campaignContent.defaults = defaultContentfulCampaign.fields;
+
+        Object.keys(contentfulCampaignFields).forEach((key) => {
+          const fieldName = contentfulCampaignFields[key];
+          result[fieldName] = {};
+
+          if (campaignContent.overrides[fieldName]) {
+            result[fieldName].override = true;
+            result[fieldName].raw = campaignContent.overrides[fieldName];
+          } else {
+            result[fieldName].override = false;
+            result[fieldName].raw = campaignContent.defaults[fieldName];
+          }
+        });
+
+        return resolve(result);
+      })
       .catch(err => reject(err));
   });
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -10,22 +10,26 @@ const logger = app.locals.logger;
 const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
 
 const defaultCampaignId = process.env.CONTENTFUL_DEFAULT_CAMPAIGN_ID || 'default';
+
+// The sequence we define peroperties here determines the order they appear in GET Gambit Campaigns
+// API response. Should match the sequence defined in Contentful, which is based on the order in
+// which our end user will see the messages.
 const contentfulCampaignFields = {
-  ask_caption: 'askCaptionMessage',
-  ask_photo: 'askPhotoMessage',
-  ask_quantity: 'askQuantityMessage',
-  ask_why_participated: 'askWhyParticipatedMessage',
-  campaign_closed: 'campaignClosedMessage',
-  invalid_cmd_signedup: 'invalidSignupMenuCommandMessage',
-  invalid_cmd_completed: 'invalidCompletedMenuCommandMessage',
-  invalid_quantity: 'invalidQuantityMessage',
-  member_support: 'memberSupportMessage',
-  menu_completed: 'completedMenuMessage',
-  menu_signedup_external: 'externalSignupMenuMessage',
   menu_signedup_gambit: 'gambitSignupMenuMessage',
+  menu_signedup_external: 'externalSignupMenuMessage',
+  invalid_cmd_signedup: 'invalidSignupMenuCommandMessage',
+  ask_quantity: 'askQuantityMessage',
+  invalid_quantity: 'invalidQuantityMessage',
+  ask_photo: 'askPhotoMessage',
   no_photo_sent: 'invalidPhotoMessage',
-  scheduled_relative_to_reportback_date: 'scheduledRelativeToReportbackDateMessage',
+  ask_caption: 'askCaptionMessage',
+  ask_why_participated: 'askWhyParticipatedMessage',
+  menu_completed: 'completedMenuMessage',
+  invalid_cmd_completed: 'invalidCompletedMenuCommandMessage',
   scheduled_relative_to_signup_date: 'scheduledRelativeToSignupDateMessage',
+  scheduled_relative_to_reportback_date: 'scheduledRelativeToReportbackDateMessage',
+  member_support: 'memberSupportMessage',
+  campaign_closed: 'campaignClosedMessage',
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -91,6 +91,10 @@ module.exports.generatePassword = function (text) {
 module.exports.replacePhoenixCampaignVars = function (input, phoenixCampaign, signupKeyword) {
   return new Promise((resolve, reject) => {
     logger.debug(`replacePhoenixCampaignVars campaignId:${phoenixCampaign.id}`);
+    if (!input) {
+      return resolve('');
+    }
+
     let scope = input;
 
     try {


### PR DESCRIPTION
#### What's this PR do?
Adds a `messages` property to the GET `campaigns/:id` response, with keys corresponding to various Gambit message types, which we define as fields on our Contentful Campaign content type in Gambini. For each Contentful Campaign field name, we store an object with keys:
* `raw` -- the copy stored in Contentful to use
* `override` -- boolean value specifying whether the `raw` value is defined on the entry for the given Campaign ID, or the default Campaign
* `rendered` -- the rendered copy, replacing the Liquid style variable tags with values from the Phoenix Campaign.

Example response:
````
{
  "data": {
    "id": "7483",
    "title": "Rinse, Recycle, Repeat",
    "status": "active",
    "messages": {
      "gambitSignupMenuMessage": {
        "override": true,
        "raw": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!",
        "rendered": "Great - it's simple: Keep beauty and personal care products out of landfills by making fun and creative recycling bins for the bathroom! \n\nThis action should take between 10 - 20 mins. Make it colorful so friends and family won't forget to recycle their bathroom empties. \n\nWhen you're done, text START to share a photo of your bin and you'll be entered to win a $5000 scholarship!"
      },
      "externalSignupMenuMessage": {
        "override": true,
        "raw": "Thanks for joining Rinse Recycle Repeat!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text {{cmd_reportback}} to share it with us!",
        "rendered": "Thanks for joining Rinse Recycle Repeat!\n\nNearly half of Americans don’t regularly recycle their beauty and personal care products. That’s a major reason these items account for a significant amount of landfill waste.\n\nThe solution is simple: Make fun and creative bins for bathrooms.\n\nOnce you have created some bathroom recycling bins, take a pic to prove it! Then text P to share it with us!"
      },
      "invalidSignupMenuCommandMessage": {
        "override": false,
        "raw": "Sorry, I didn't understand that.\n\nText {{cmd_reportback}} when you have {{rb_verb}} some {{rb_noun}}.\n\nIf you have a question, text {{cmd_member_support}}.",
        "rendered": "Sorry, I didn't understand that.\n\nText P when you have decorated some bins.\n\nIf you have a question, text Q."
      },
      "askQuantityMessage": {
        "override": false,
        "raw": "Sweet! First, what's the total number of {{rb_noun}} you {{rb_verb}}?\n\nSend the exact number back.",
        "rendered": "Sweet! First, what's the total number of bins you decorated?\n\nSend the exact number back."
      },
      "invalidQuantityMessage": {
        "override": false,
        "raw": "Sorry, that's not a valid number.\n\nWhat's the total number of {{rb_noun}} you have {{rb_verb}}?\n\nIf you have a question, text {{cmd_member_support}}.",
        "rendered": "Sorry, that's not a valid number.\n\nWhat's the total number of bins you have decorated?\n\nIf you have a question, text Q."
      },
      ....
````

#### How should this be reviewed?

**Local**
Pull this branch down and run Gambit locally. Verify that GET `/campaigns` doesn't return a `messages` object, but GET `/campaigns/:id` does.

**Staging**
Upon deploying this branch to staging, verify:
* http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns
* http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/3590 -- no overrides
* http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/7483 -- contains overrides

#### Any background context you want to provide?
* This will be used by our [Slothbot](github.com/dosomething/slothbot) Slack app to allow staffers to preview all possible rendered messages Gambit will return for a Campaign.
* Avoiding rendering all messages on the GET campaigns index endpoint to help performance (and there aren't any apps that depend on the `messages` there)

#### Relevant tickets
Fixes #798

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
