### PR TITLE
Adds contentfulUri property to GET campaigns/:id

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -89,9 +89,22 @@ router.get('/', (req, res) => {
 router.get('/:id', (req, res) => {
   stathat('route: v1/campaigns/{id}');
   const campaignId = req.params.id;
+  let response;
 
   return fetchCampaign(campaignId, true)
-    .then(data => res.send({ data }))
+    .then((data) => {
+      response = data;
+
+      return contentful.fetchCampaign(campaignId);
+    })
+    .then((contentfulCampaign) => {
+      const spaceId = process.env.CONTENTFUL_SPACE_ID;
+      const contentfulId = contentfulCampaign.sys.id;
+      const uri = `https://app.contentful.com/spaces/${spaceId}/entries/${contentfulId}`;
+      response.contentfulUri = uri;
+
+      return res.send({ response });
+    })
     // TODO: Refactor helpers.sendResponse to accept an error and know the codes based on custom
     // error class, to DRY.
     .catch(NotFoundError, err => helpers.sendResponse(res, 404, err.message))

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -103,7 +103,7 @@ router.get('/:id', (req, res) => {
       const uri = `https://app.contentful.com/spaces/${spaceId}/entries/${contentfulId}`;
       response.contentfulUri = uri;
 
-      return res.send({ response });
+      return res.send({ data: response });
     })
     // TODO: Refactor helpers.sendResponse to accept an error and know the codes based on custom
     // error class, to DRY.

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -188,7 +188,8 @@ curl http://localhost:5000/v1/campaigns/7483 \
       {
         "keyword": "RINSEBOT"
       }
-    ]
+    ],
+    "contentfulUri": "https://app.contentful.com/spaces/pupp3tSl0Th/entries/3tUIp8oqTemqaSOKqGwIe6"
   }
 }
 ```


### PR DESCRIPTION
#### What's this PR do?
Adds the URL for a Campaign's Contentful Campaign entry to the GET `campaigns/:id` response.

#### How should this be reviewed?
Using a JSON viewer in browser, make a GET campaigns/:id response and verify the URL's click through to the correct Contentful entries.

#### Any background context you want to provide?
This will make life easier for content admins when we expose the URL to [Slothbot](https://github.com/dosomething/slothbot) messaging.

#### Relevant tickets
#798, https://github.com/DoSomething/slothbot/pull/6

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
