### PR TITLE
Add function names to error messages

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -50,7 +50,12 @@ campaignSchema.statics.lookupByIds = function (campaignIds) {
 
         return resolve(Promise.all(promises));
       })
-      .catch(error => reject(error));
+      .catch((err) => {
+        const scope = err;
+        scope.message = `Campaign.lookupByIds error:${err.message}`;
+
+        return reject(scope);
+      });
   });
 };
 
@@ -69,9 +74,7 @@ campaignSchema.methods.findOrCreateMessagingGroups = function () {
       this.mobilecommons_group_completed = groups.completed;
       return this.save();
     })
-    .catch((error) => {
-      logger.error(`findOrCreateMessagingGroups() caught an error: ${error.message}`);
-    });
+    .catch(error => logger.error(`Campaign.findOrCreateMessagingGroups error: ${error.message}`));
 };
 
 /**

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -89,7 +89,9 @@ signupSchema.statics.lookupById = function (id) {
           return reject(notFoundError);
         }
 
-        return reject(err);
+        const scope = err;
+        scope.message = `Signup.lookupById error:${err.message}`;
+        return reject(scope);
       });
   });
 };
@@ -129,8 +131,10 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
       .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
         app.locals.stathatError(statName, err);
+        const scope = err;
+        scope.message = `Signup.lookupCurrent error:${err.message}`;
 
-        return reject(err);
+        return reject(scope);
       });
   });
 };
@@ -171,8 +175,10 @@ signupSchema.statics.post = function (user, campaign, keyword) {
       .then(signupDoc => resolve(signupDoc))
       .catch((err) => {
         app.locals.stathatError(statName, err);
+        const scope = err;
+        scope.message = `Signup.post error:${err.message}`;
 
-        return reject(err);
+        return reject(scope);
       });
   });
 };
@@ -203,7 +209,12 @@ signupSchema.methods.createDraftReportbackSubmission = function () {
 
         return resolve(updatedSignup);
       })
-      .catch(err => reject(err));
+      .catch((err) => {
+        const scope = err;
+        scope.message = `Signup.post error:${err.message}`;
+
+        return reject(scope);
+      });
   });
 };
 
@@ -257,7 +268,10 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
         submission.failed_at = dateSubmitted;
         submission.save();
 
-        return reject(err);
+        const scope = err;
+        scope.message = `Signup.post error:${err.message}`;
+
+        return reject(scope);
       });
   });
 };

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -66,10 +66,12 @@ userSchema.statics.lookup = function (type, id) {
         return model.findOneAndUpdate(query, userData, helpers.upsertOptions()).exec();
       })
       .then(userDoc => resolve(userDoc))
-      .catch((error) => {
-        app.locals.stathatError(statName, error);
+      .catch((err) => {
+        app.locals.stathatError(statName, err);
+        const scope = err;
+        scope.message = `User.lookup error:${err.message}`;
 
-        return reject(error);
+        return reject(scope);
       });
   });
 };
@@ -81,16 +83,16 @@ userSchema.statics.post = function (data) {
   const model = this;
   const statName = 'northstar: POST users';
 
-  const scope = data;
-  scope.source = process.env.DS_API_USER_REGISTRATION_SOURCE || 'sms';
-  scope.password = helpers.generatePassword(data.mobile);
+  const createUser = data;
+  createUser.source = process.env.DS_API_USER_REGISTRATION_SOURCE || 'sms';
+  createUser.password = helpers.generatePassword(data.mobile);
   const emailDomain = process.env.DS_API_DEFAULT_USER_EMAIL || 'mobile.import';
-  scope.email = `${data.mobile}@${emailDomain}`;
+  createUser.email = `${data.mobile}@${emailDomain}`;
 
   return new Promise((resolve, reject) => {
     logger.debug('User.post');
 
-    return northstar.Users.create(scope)
+    return northstar.Users.create(createUser)
       .then((northstarUser) => {
         app.locals.stathat(`${statName} 200`);
         logger.info(`northstar.Users created user:${northstarUser.id}`);
@@ -100,10 +102,12 @@ userSchema.statics.post = function (data) {
         return model.findOneAndUpdate(query, userData, helpers.upsertOptions()).exec();
       })
       .then(userDoc => resolve(userDoc))
-      .catch((error) => {
-        app.locals.stathatError(statName, error);
+      .catch((err) => {
+        app.locals.stathatError(statName, err);
+        const scope = err;
+        scope.message = `User.post error:${err.message}`;
 
-        return reject(error);
+        return reject(scope);
       });
   });
 };

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -25,7 +25,7 @@ function fetchCampaign(id, renderMessages) {
   return new Promise((resolve, reject) => {
     logger.debug(`fetchCampaign:${id}`);
 
-    return phoenix.client.Campaigns.get(id)
+    return phoenix.fetchCampaign(id)
       .then((phoenixCampaign) => {
         campaign.title = phoenixCampaign.title;
         campaign.status = phoenixCampaign.status;
@@ -60,7 +60,7 @@ function fetchCampaign(id, renderMessages) {
         return resolve(campaign);
       })
       .catch(error => {
-        if (error.message === 'Not Found') {
+        if (error.status === 404) {
           const notFoundError = new NotFoundError(`Campaign ${id} not found`);
           return reject(notFoundError);
         }
@@ -136,9 +136,8 @@ router.post('/:id/message', (req, res) => {
     logger.debug(`loadCampaignMessage campaign:${campaignId} msgType:${type}`);
     let campaign;
 
-    return phoenix.client.Campaigns.get(campaignId)
+    return phoenix.fetchCampaign(campaignId)
       .then((phoenixCampaign) => {
-        logger.debug(`phoenix.client.Campaigns.get found campaign:${campaignId}`);
         if (phoenix.isClosedCampaign(phoenixCampaign)) {
           const err = new ClosedCampaignError(phoenixCampaign);
           return reject(err);

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -143,7 +143,7 @@ router.post('/', (req, res) => {
               logger.info(`loaded broadcast:${scope.broadcast_id}`);
               const campaignId = currentBroadcast.fields.campaign.fields.campaignId;
 
-              return phoenix.client.Campaigns.get(campaignId);
+              return phoenix.fetchCampaign(campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -180,8 +180,10 @@ router.post('/', (req, res) => {
                 const err = new Error(msg);
                 return reject(err);
               }
+              const campaignId = keyword.fields.campaign.fields.campaignId;
+              logger.debug(`keyword campaignId:${campaignId}`);
 
-              return phoenix.client.Campaigns.get(keyword.fields.campaign.fields.campaignId);
+              return phoenix.fetchCampaign(campaignId);
             })
             .then((campaign) => {
               if (!campaign.id) {
@@ -198,7 +200,7 @@ router.post('/', (req, res) => {
 
         // If we've made it this far, check for User's current_campaign.
         logger.debug(`user.current_campaign:${user.current_campaign}`);
-        return phoenix.client.Campaigns.get(user.current_campaign)
+        return phoenix.fetchCampaign(user.current_campaign)
           .then((campaign) => {
             if (!campaign.id) {
               // TODO: Send to non-existent start menu to select a campaign.
@@ -366,8 +368,12 @@ router.post('/', (req, res) => {
       }
 
       stathat(err.message);
+      let errStatus = err.status;
+      if (!errStatus) {
+        errStatus = 500;
+      }
 
-      return helpers.sendResponse(res, 500, err.message);
+      return helpers.sendResponse(res, errStatus, err.message);
     });
 });
 

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -45,7 +45,7 @@ router.post('/', (req, res) => {
     .then((signup) => {
       scope.signup = signup;
 
-      return phoenix.client.Campaigns.get(signup.campaign);
+      return phoenix.fetchCampaign(signup.campaign);
     })
     .then((phoenixCampaign) => {
       if (phoenix.isClosedCampaign(phoenixCampaign)) {

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -22,6 +22,33 @@ try {
 
 module.exports.client = client;
 
+/**
+ * Returns given DS Campaign object is closed.
+ *
+ * @param {Object} phoenixCampaign
+ * @return {boolean}
+ */
 module.exports.isClosedCampaign = function (phoenixCampaign) {
   return (phoenixCampaign.status === 'closed');
+};
+
+/**
+ * Fetches a DS Campaign for the given campaignId.
+ *
+ * @param {number} campaignId
+ * @return {Promise}
+ */
+module.exports.fetchCampaign = function (campaignId) {
+  logger.debug(`phoenix.fetchCampaign:${campaignId}`);
+
+  return new Promise((resolve, reject) => {
+    client.Campaigns.get(campaignId)
+      .then(phoenixCampaign => resolve(phoenixCampaign))
+      .catch((err) => {
+        const scope = err;
+        scope.message = `phoenix.fetchCampaign:${campaignId} ${err.message}`;
+
+        return reject(scope);
+      });
+  });
 };


### PR DESCRIPTION
#### What's this PR do?
Adds a suffix to error messages in our Model static functions (and a new Phoenix `fetchCampaign` helper function) to help troubleshoot where network errors come from.

#### How should this be reviewed?
Try to break things. One way to see the prefix in action is by attempting to post a signup keyword (for a campaign you haven't signed up for), but with an invalid `DS_PHOENIX_API_PASSWORD` config variable. Instead of a 500 error, the returned response should look like:
````
{
 "error": {
   "code": 401,
   "message": "Signup.post error:Unauthorized"
 }
}
````

#### Any background context you want to provide?
We mostly see these errors when during high volume after sending out a broadcasts.

#### Relevant tickets
Fixes #816 , Refs #810 

#### Checklist
- [x] Tested on staging.
