### PR TITLE
Deprecate CampaignBotController.createReportbackSubmission

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -109,24 +109,6 @@ class CampaignBotController {
   }
 
   /**
-   * TODO: Move into router.
-   * Creates new ReportbackSubmission model and updates Signup model's draft.
-   * @param {object} req - Express request
-   * @return {string} - Message to send and begin collecting Reportback data.
-   */
-  createReportbackSubmission(req) {
-    this.debug(req, 'createReportbackSubmission');
-
-    return req.signup
-      .createDraftReportbackSubmission()
-      .then(() => {
-        this.debug(req, `updated signup:${req.signup._id.toString()}`);
-
-        return this.collectReportbackProperty(req, 'quantity', true);
-      });
-  }
-
-  /**
    * Wrapper function for logger.debug(msg)
    */
   debug(req, msg) {

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -190,7 +190,8 @@ signupSchema.methods.createDraftReportbackSubmission = function () {
   const signup = this;
 
   return new Promise((resolve, reject) => {
-    logger.debug('Signup.createDraftReportbackSubmission');
+    const logPrefix = 'Signup.createDraftReportbackSubmission';
+    logger.debug(logPrefix);
 
     return ReportbackSubmission
       .create({
@@ -199,12 +200,13 @@ signupSchema.methods.createDraftReportbackSubmission = function () {
       })
       .then(reportbackSubmission => {
         const submissionId = reportbackSubmission._id;
-        logger.debug(`Signup.createDraftReportbackSubmission created:${submissionId.toString()}`);
+        logger.debug(`${logPrefix} created reportback_submission:${submissionId.toString()}`);
         signup.draft_reportback_submission = submissionId;
 
         return signup.save();
       })
       .then((updatedSignup) => {
+        logger.debug(`${logPrefix} updated signup:${signup._id}`);
         app.locals.stathat('created draft_reportback_submission');
 
         return resolve(updatedSignup);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -213,7 +213,7 @@ signupSchema.methods.createDraftReportbackSubmission = function () {
       })
       .catch((err) => {
         const scope = err;
-        scope.message = `Signup.post error:${err.message}`;
+        scope.message = `Signup.createDraftReportbackSubmission error:${err.message}`;
 
         return reject(scope);
       });
@@ -271,7 +271,7 @@ signupSchema.methods.postDraftReportbackSubmission = function () {
         submission.save();
 
         const scope = err;
-        scope.message = `Signup.post error:${err.message}`;
+        scope.message = `Signup.postDraftReportbackSubmission error:${err.message}`;
 
         return reject(scope);
       });

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -71,6 +71,7 @@ router.post('/', (req, res) => {
 
   if (req.body.keyword) {
     scope.keyword = req.body.keyword.toLowerCase();
+    logger.debug(`keyword:${scope.keyword}`);
     logRequest.keyword = scope.keyword;
   }
 
@@ -261,7 +262,7 @@ router.post('/', (req, res) => {
       }
 
       if (isCommand(scope.incoming_message, 'reportback')) {
-        return controller.createReportbackSubmission(scope);
+        return scope.signup.createDraftReportbackSubmission().then(() => 'ask_quantity');
       }
 
       if (scope.signup.reportback) {


### PR DESCRIPTION
#### What's this PR do?
Starts chipping away at #744 by removing the extraneous `CampaignBotController.createReportbackSubmission` call in the `chatbot` router, directly calling `Signup.createDraftReportbackSubmission` instead.

#### How should this be reviewed?
* Remove your Signup for a given Campaign
    * Use the Phoenix Unsignup form to delete from Phoenix DB
    * Delete your local `signups` document for your user/campaign if exists
* Post the keyword for the Campaign
* Verify Signup is created
* Post the Reportback command
* Verify the Signup's `draft_reportback_submission` is populated, and the Ask Quantity message is returned

#### Any background context you want to provide?
Opening this up as a bite-sized PR that's easy to review before starting to take on moving the CampaignBotController `collectReportbackProperty` and `continueReportbackSubmission` functions into the `ReportbackSubmission` model and `chatbot` router.

#723 -- old PR moving many more `CampaignBotController` functions out into model classes

#### Relevant tickets
#744 

#### Checklist
- [x] Tested on staging.
