### PR TITLE
Add New Relic Native Metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "@dosomething/phoenix-js": "git://github.com/DoSomething/phoenix-js.git",
+    "@newrelic/native-metrics": "^2.1.0",
     "bluebird": "^3.4.6",
     "body-parser": "^1.9.2",
     "connect-multiparty": "1.1.0",


### PR DESCRIPTION
#### What's this PR do?
Installs the [New Relic Native Metrics](https://docs.newrelic.com/docs/agents/nodejs-agent/supported-features/node-vm-measurements) module to "gain insights into garbage collection and event loop behavior", turning this:

<img width="1191" alt="screen shot 2017-03-24 at 9 35 51 am" src="https://cloud.githubusercontent.com/assets/1236811/24304062/5e5fe912-1075-11e7-97a6-790f119a6642.png">

into this:

<img width="1404" alt="screen shot 2017-03-24 at 9 31 27 am" src="https://cloud.githubusercontent.com/assets/1236811/24304066/6589a2a0-1075-11e7-80d7-011a9a970df4.png">

#### How should this be reviewed?

* Check it out on staging upon deploying this branch, or enable New Relic locally and set it to the `Gambit Local` app, which is where screenshot above is from.

```
NEW_RELIC_ENABLED=true 
NEW_RELIC_APP_NAME=Gambit Local
```

#### Relevant tickets
https://github.com/DoSomething/gambit/pull/825#issuecomment-288776394

#### Checklist
- [x] Tested on staging.

