### PR TITLE
Query Phoenix instead of Northstar for Signups

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -42,19 +42,19 @@ const signupSchema = new mongoose.Schema({
 
 });
 
-function parseNorthstarSignup(northstarSignup) {
+function parsePhoenixSignup(phoenixSignup) {
   const data = {
-    _id: Number(northstarSignup.id),
-    user: northstarSignup.user,
-    campaign: Number(northstarSignup.campaign),
+    _id: Number(phoenixSignup.id),
+    user: phoenixSignup.user,
+    campaign: Number(phoenixSignup.campaign),
   };
   // Only set if this was called from postSignup(req).
-  if (northstarSignup.keyword) {
-    data.keyword = northstarSignup.keyword;
+  if (phoenixSignup.keyword) {
+    data.keyword = phoenixSignup.keyword;
   }
-  if (northstarSignup.reportback) {
-    data.reportback = Number(northstarSignup.reportback.id);
-    data.total_quantity_submitted = northstarSignup.reportback.quantity;
+  if (phoenixSignup.reportback) {
+    data.reportback = Number(phoenixSignup.reportback.id);
+    data.total_quantity_submitted = phoenixSignup.reportback.quantity;
   }
 
   return data;
@@ -66,16 +66,16 @@ function parseNorthstarSignup(northstarSignup) {
  */
 signupSchema.statics.lookupById = function (id) {
   const model = this;
-  const statName = 'northstar: GET signups/{id}';
+  const statName = 'phoenix: GET signups/{id}';
 
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupById:${id}`);
 
     return phoenix.client.Signups.get(id)
-      .then((northstarSignup) => {
+      .then((phoenixSignup) => {
         app.locals.stathat(`${statName} 200`);
-        logger.debug(`northstar.Signups.get:${id} success`);
-        const data = parseNorthstarSignup(northstarSignup);
+        logger.debug(`phoenix.Signups.get:${id} success`);
+        const data = parsePhoenixSignup(phoenixSignup);
 
         return model.findOneAndUpdate({ _id: id }, data, helpers.upsertOptions()).exec();
       })
@@ -102,25 +102,25 @@ signupSchema.statics.lookupById = function (id) {
  */
 signupSchema.statics.lookupCurrent = function (user, campaign) {
   const model = this;
-  const statName = 'northstar: GET signups';
+  const statName = 'phoenix: GET signups';
 
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupCurrent(${user._id}, ${campaign.id})`);
 
     return phoenix.client.Signups.index({ user: user._id, campaigns: campaign.id })
-      .then((northstarSignups) => {
+      .then((phoenixSignups) => {
         app.locals.stathat(`${statName} 200`);
 
-        if (northstarSignups.length < 1) {
+        if (phoenixSignups.length < 1) {
           return resolve(false);
         }
 
-        const currentSignup = northstarSignups.find(signup => signup.campaignRun.current);
+        const currentSignup = phoenixSignups.find(signup => signup.campaignRun.current);
         if (!currentSignup) {
           return resolve(false);
         }
 
-        const data = parseNorthstarSignup(currentSignup);
+        const data = parsePhoenixSignup(currentSignup);
 
         return model.findOneAndUpdate({ _id: data._id }, data, helpers.upsertOptions())
           .populate('user')

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -8,7 +8,6 @@ const Promise = require('bluebird');
 const ReportbackSubmission = require('./ReportbackSubmission');
 const NotFoundError = require('../exceptions/NotFoundError');
 const helpers = require('../../lib/helpers');
-const northstar = require('../../lib/northstar');
 const phoenix = require('../../lib/phoenix');
 const logger = app.locals.logger;
 
@@ -72,7 +71,7 @@ signupSchema.statics.lookupById = function (id) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupById:${id}`);
 
-    return northstar.Signups.get(id)
+    return phoenix.client.Signups.get(id)
       .then((northstarSignup) => {
         app.locals.stathat(`${statName} 200`);
         logger.debug(`northstar.Signups.get:${id} success`);
@@ -108,7 +107,7 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
   return new Promise((resolve, reject) => {
     logger.debug(`Signup.lookupCurrent(${user._id}, ${campaign.id})`);
 
-    return northstar.Signups.index({ user: user._id, campaigns: campaign.id })
+    return phoenix.client.Signups.index({ user: user._id, campaigns: campaign.id })
       .then((northstarSignups) => {
         app.locals.stathat(`${statName} 200`);
 


### PR DESCRIPTION
#### What's this PR do?
Updates `Signup` model per https://github.com/DoSomething/phoenix-js/pull/19 to work toward a fix for #827. Currently we [get a null `user.id` back in the Signups response](https://github.com/dosomething/gambit/issues/827#issuecomment-289496978), so #827 isn't fixed until that's resolved.

#### How should this be reviewed?
Post a keyword to chatbot to complete a campaign: 
* Your Signup should load correctly and you should be able to continue the conversation, but... 
* Posting your Reportback should fail with `postReportback error:Cannot read property 'phoenix_id' of null`.
    * Gambit tries to load a document for a null user, and doesn't have the User properties it needs (like the `phoenix_id`)


#### Relevant tickets
* #827
* https://github.com/DoSomething/phoenix-js/pull/19
* https://github.com/DoSomething/phoenix/issues/7329
#### Checklist
- [x] Tested on staging.
