### PR TITLE
Adds timedout check to Chatbot find/create user

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -70,6 +70,24 @@ router.use((req, res, next) => {
 });
 
 /**
+ * Check for required body parameters.
+ */
+router.use((req, res, next) => {
+  if (!req.body.phone) {
+    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required phone.');
+  }
+  if (!(req.body.args || req.body.mms_image_url)) {
+    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required args or mms_image_url.');
+  }
+  /* eslint-disable no-param-reassign */
+  req.incoming_message = req.body.args;
+  req.incoming_image_url = req.body.mms_image_url;
+  /* eslint-enable no-param-reassign */
+
+  return next();
+});
+
+/**
  * Posts to chatbot route will find or create a Northstar User for the given req.body.phone.
  * Currently only supports Mobile Commons mData's.
  */
@@ -112,12 +130,6 @@ router.post('/', (req, res) => {
     mobileCommonsMessageId: scope.body.message_id,
     mobileCommonsProfileId: req.body.profile_id,
   });
-
-  if (!req.body.phone) {
-    stathat.postStat('error: undefined req.body.phone');
-
-    return res.status(422).send({ error: 'phone is required.' });
-  }
 
   const loadUser = new Promise((resolve, reject) => {
     logger.log('loadUser');

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -76,9 +76,11 @@ router.use((req, res, next) => {
   if (!req.body.phone) {
     return helpers.sendUnproccessibleEntityResponse(res, 'Missing required phone.');
   }
-  if (!(req.body.args || req.body.mms_image_url)) {
-    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required args or mms_image_url.');
+  if (!(req.body.keyword || req.body.args || req.body.mms_image_url)) {
+    const msg = 'Missing required keyword, args, or mms_image_url.';
+    return helpers.sendUnproccessibleEntityResponse(res, msg);
   }
+
   /* eslint-disable no-param-reassign */
   req.client = 'mobilecommons';
   req.incoming_message = req.body.args;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -140,6 +140,7 @@ module.exports.sendResponse = function (res, code, message) {
   if (code > 200) {
     type = 'error';
     logger.error(message);
+    stathat.postStat(`${code}: ${message}`);
   }
 
   const response = {};
@@ -162,9 +163,17 @@ module.exports.getGambitTimeoutNumSeconds = function () {
  */
 module.exports.sendTimeoutResponse = function (res) {
   const timeoutNumSeconds = this.getGambitTimeoutNumSeconds();
-  stathat.postStat(`timeout ${timeoutNumSeconds}s`);
 
   return this.sendResponse(res, 504, `Request timed out after ${timeoutNumSeconds} seconds.`);
+};
+
+/**
+ * Sends a 422 with given message.
+ * @param {object} res - Express response
+ * @param {object} message - Express response
+ */
+module.exports.sendUnproccessibleEntityResponse = function (res, message) {
+  return this.sendResponse(res, 422, message);
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -167,6 +167,15 @@ module.exports.sendTimeoutResponse = function (res) {
   return this.sendResponse(res, 504, `Request timed out after ${timeoutNumSeconds} seconds.`);
 };
 
+module.exports.sendErrorResponse = function (res, err) {
+  let status = err.status;
+  if (!status) {
+    status = 500;
+  }
+
+  return this.sendResponse(res, status, err.message);
+};
+
 /**
  * Sends a 422 with given message.
  * @param {object} res - Express response

--- a/lib/stathat.js
+++ b/lib/stathat.js
@@ -18,7 +18,10 @@ module.exports.postStat = function (statName) {
   const appName = process.env.STATHAT_APP_NAME || 'gambit';
   const stat = `${appName} - ${statName}`;
   // Bump count of stat by 1.
-  stathat.trackEZCount(key, stat, 1, status => logger.debug(`stathat:${stat} ${status}`));
+  stathat.trackEZCount(key, stat, 1, (status) => {
+    const msg = `stathat response:${status} for sending stat:'${stat}'`;
+    logger.debug(msg);
+  });
 };
 
 /**

--- a/lib/stathat.js
+++ b/lib/stathat.js
@@ -19,7 +19,7 @@ module.exports.postStat = function (statName) {
   const stat = `${appName} - ${statName}`;
   // Bump count of stat by 1.
   stathat.trackEZCount(key, stat, 1, (status) => {
-    const msg = `stathat response:${status} for sending stat:'${stat}'`;
+    const msg = `stathat response:${status} postStat:'${stat}'`;
     logger.debug(msg);
   });
 };


### PR DESCRIPTION
#### What's this PR do?
Begins work on #824 and #849 by splitting out checks for finding/creating a User for a given phone number, and adding `req.timedout` checks per #852.

#### How should this be reviewed?
* Use existing user, create new user
* Test with local connectivity/timeout settings to verify request will timeout:
```
9:50:35 AM web.1 |  debug: User.lookup(mobile, [removed])
9:50:47 AM web.1 |  debug: northstar.Users.lookup success
9:50:47 AM web.1 |  error: Request timed out after 2 seconds.
```
#### Any background context you want to provide?
Next up: splitting out loading Campaign and Signup into smaller functions. 

#### Relevant tickets
#824, #849, #852

#### Checklist
- [x] Tested on staging.
