### PR TITLE
Chatbot middleware to determine current Campaign 

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -311,6 +311,7 @@ router.post('/', (req, res) => {
       }
 
       if (scope.broadcast_id) {
+        // TODO: Add new parameter for broadcast_id to Signup post instead of saving here.
         scope.signup.broadcast_id = scope.broadcast_id;
         scope.signup.save().catch((err) => logger.error('Error saving broadcast id', err.message));
       }

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -208,6 +208,37 @@ router.use((req, res, next) => {
     .catch(err => helpers.sendErrorResponse(res, err));
 });
 
+/**
+ * If we don't have a campaignId yet and incoming request contains a keyword, set the campaignId.
+ */
+router.use((req, res, next) => {
+  if (req.campaignId || !req.keyword) {
+    return next();
+  }
+  return contentful.fetchKeyword(req.keyword)
+    .then((keyword) => {
+      if (req.timedout) {
+        return helpers.sendTimeoutResponse(res);
+      }
+      if (!keyword) {
+        return helpers.sendResponse(res, 404, `Keyword ${req.keyword} not found.`);
+      }
+      if (keyword.fields.environment !== process.env.NODE_ENV) {
+        const msg = `Keyword ${req.keyword} environment error: defined as ${keyword.environment} ` +
+                    `but sent to ${process.env.NODE_ENV}.`;
+        return helpers.sendResponse(res, 500, msg);
+      }
+      const keywordCampaign = keyword.fields.campaign.fields;
+      req.campaignId = keywordCampaign.campaignId; // eslint-disable-line no-param-reassign
+
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+});
+
+/**
+ * Load Campaign from DS API.
+ */
 router.post('/', (req, res) => {
   phoenix.fetchCampaign(req.campaignId)
     .then((phoenixCampaign) => {
@@ -228,41 +259,6 @@ router.post('/', (req, res) => {
   const scope = req;
 
   const loadCampaign = new Promise((resolve, reject) => {
-    logger.log('loadCampaign');
-
-    if (scope.keyword) {
-      return contentful.fetchKeyword(scope.keyword)
-        .then((keyword) => {
-          if (!keyword) {
-            const err = new NotFoundError(`keyword ${scope.keyword} not found`);
-            return reject(err);
-          }
-          logger.debug(`found keyword:${JSON.stringify(keyword.fields)}`);
-
-          if (keyword.fields.environment !== process.env.NODE_ENV) {
-            let msg = `mData misconfiguration: ${keyword.environment} keyword sent to`;
-            msg = `${msg} ${process.env.NODE_ENV}`;
-            const err = new Error(msg);
-            return reject(err);
-          }
-          const campaignId = keyword.fields.campaign.fields.campaignId;
-          logger.debug(`keyword campaignId:${campaignId}`);
-
-          return phoenix.fetchCampaign(campaignId);
-        })
-        .then((campaign) => {
-          if (!campaign.id) {
-            const msg = `Campaign not found for keyword '${scope.keyword}'.`;
-            const err = new NotFoundError(msg);
-            return reject(err);
-          }
-          logger.debug(`found campaign:${campaign.id}`);
-
-          return resolve(campaign);
-        })
-        .catch(err => reject(err));
-    }
-
     // If we've made it this far, check for User's current_campaign.
     logger.debug(`user.current_campaign:${req.user.current_campaign}`);
     // TODO: Check if current_campaign is undefined before fetching.


### PR DESCRIPTION
#### What's this PR do?
* Splits out the code that checks for the current Campaign into middleware functions, maintaining the same order:
   * If a `broadcast_id` was sent, query Contentful Broadcasts to set a `req.campaignId` (and send the Declined Message if User sent a No response)
   * If a `keyword` was sent, query Contentful Keywords to set a `req.campaignId`
   * Else we should have a current Campaign ID set on the User document already.

* Adds timeout checks to the Contentful queries

#### How should this be reviewed?
* Verify expected behavior for the three scenarios listed above

#### Any background context you want to provide?
Next up for splitting into middleware (and adding timeout checks):
* Loading the Campaign via Phoenix API
* Finding/creating the Signup via Phoenix API 

#### Relevant tickets
#853, #849, #824 

#### Checklist
- [x] Tested on staging.
