### PR TITLE
Cleanup

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -416,35 +416,7 @@ router.post('/', (req, res) => {
         })
         .catch(renderError => helpers.sendResponse(res, 500, renderError.message));
     })
-    .catch(err => {
-      if (err.message === 'broadcast declined') {
-        logger.info('broadcast declined');
-        scope.response_message = scope.broadcast.fields.declinedMessage;
-        if (!scope.response_message) {
-          const logMsg = 'undefined broadcast.declinedMessage';
-          logger.error(logMsg);
-          stathat.postStat(`error: ${logMsg}`);
-
-          // Don't send an error code to Mobile Commons, which would trigger error message to User.
-          return helpers.sendResponse(res, 200, logMsg);
-        }
-        const msg = helpers.addSenderPrefix(scope.response_message);
-        // Log the no response:
-        BotRequest.log(req, 'broadcast', null, 'prompt_declined', msg);
-        // Send broadcast declined using Mobile Commons Send Message API:
-        mobilecommons.send_message(scope.user.mobile, msg);
-
-        return helpers.sendResponse(res, 200, msg);
-      }
-
-      stathat.postStat(err.message);
-      let errStatus = err.status;
-      if (!errStatus) {
-        errStatus = 500;
-      }
-
-      return helpers.sendResponse(res, errStatus, err.message);
-    });
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 module.exports = router;

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -24,11 +24,11 @@ router.use((req, res, next) => {
   logger.debug(`signups post:${JSON.stringify(req.body)}`);
 
   if (!req.body.id) {
-    return helpers.sendResponse(res, 422, 'Missing required id.');
+    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required id.');
   }
 
   if (!req.body.source) {
-    return helpers.sendResponse(res, 422, 'Missing required source.');
+    return helpers.sendUnproccessibleEntityResponse(res, 'Missing required source.');
   }
 
   const source = req.body.source;
@@ -67,7 +67,7 @@ router.use((req, res, next) => {
       }
       if (phoenix.isClosedCampaign(phoenixCampaign)) {
         const err = new ClosedCampaignError(phoenixCampaign);
-        return helpers.sendResponse(res, 422, err.message);
+        return helpers.sendUnproccessibleEntityResponse(res, err.message);
       }
       req.campaign = phoenixCampaign; // eslint-disable-line no-param-reassign
       return next();
@@ -86,11 +86,10 @@ router.use((req, res, next) => {
       }
       if (keywords.length === 0) {
         const msg = `Campaign ${req.campaign.id} does not have any Gambit keywords.`;
-        throw new UnprocessibleEntityError(msg);
+        return helpers.sendUnproccessibleEntityResponse(msg);
       }
       return next();
     })
-    .catch(UnprocessibleEntityError, err => helpers.sendResponse(res, 422, err.message))
     .catch(err => helpers.sendResponse(res, 500, err.message));
 });
 
@@ -104,12 +103,11 @@ router.use((req, res, next) => {
         return helpers.sendTimeoutResponse(res);
       }
       if (!user.mobile) {
-        throw new UnprocessibleEntityError('Missing required user.mobile.');
+        return helpers.sendUnproccessibleEntityResponse(res, 'Missing required user.mobile.');
       }
       req.user = user; // eslint-disable-line no-param-reassign
       return next();
     })
-    .catch(UnprocessibleEntityError, err => helpers.sendResponse(res, 422, err.message))
     .catch(err => helpers.sendResponse(res, 500, err.message));
 });
 

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -3,16 +3,12 @@
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
 const logger = require('winston');
-// Requiring Bluebird overrides native promises,
-// which we need for our exception handling logic in this endpoint.
-const Promise = require('bluebird'); // eslint-disable-line no-unused-vars
 
 const contentful = require('../../lib/contentful');
 const helpers = require('../../lib/helpers');
 const phoenix = require('../../lib/phoenix');
 const stathat = require('../../lib/stathat');
 const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
-const UnprocessibleEntityError = require('../exceptions/UnprocessibleEntityError');
 const Signup = require('../models/Signup');
 const User = require('../models/User');
 


### PR DESCRIPTION
#### What's this PR do?
* Removes code for handling broadcast declined that never gets called, missed this in #854 
* Implements `helpers.sendUnproccessibleEntityResponse` in Signups to DRY
* Removes unused `UnproccessibleEntityError` and `Promise` vars -- Bluebird was required for filtered catch, but Signups simply returns the `UnproccessibleEntityResponse` instead of throwing a `UnproccessibleEntityError` to catch later.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Cleaning house 🏡 


#### Checklist
- [x] Tested on staging.
