### PR TITLE
Chatbot middleware to find/create Signups

### DIFF
--- a/app/controllers/CampaignBotController.js
+++ b/app/controllers/CampaignBotController.js
@@ -86,26 +86,28 @@ class CampaignBotController {
     const submission = req.signup.draft_reportback_submission;
     const ask = req.keyword || req.broadcast_id;
 
-    if (!submission.quantity) {
-      return this.collectReportbackProperty(req, 'quantity', ask);
-    }
-    if (!submission.photo) {
-      return this.collectReportbackProperty(req, 'photo', ask);
-    }
-    if (!submission.caption) {
-      return this.collectReportbackProperty(req, 'caption', ask);
-    }
+    return new Promise((resolve) => {
+      if (!submission.quantity) {
+        return resolve(this.collectReportbackProperty(req, 'quantity', ask));
+      }
+      if (!submission.photo) {
+        return resolve(this.collectReportbackProperty(req, 'photo', ask));
+      }
+      if (!submission.caption) {
+        return resolve(this.collectReportbackProperty(req, 'caption', ask));
+      }
 
-    const askWhy = !this.hasReportedBack(req) && !submission.why_participated;
-    if (askWhy) {
-      return this.collectReportbackProperty(req, 'why_participated', ask);
-    }
+      const askWhy = !this.hasReportedBack(req) && !submission.why_participated;
+      if (askWhy) {
+        return resolve(this.collectReportbackProperty(req, 'why_participated', ask));
+      }
 
-    // If we're here, we have a completed submission but the POST request
-    // likely failed.
-    // TODO: Check failed_at before sending? Message about whoops trying again?
-    logger.warn('no messages sent from continueReportbackSubmission');
-    return this.postReportback(req);
+      // If we're here, we have a completed submission but the POST request
+      // likely failed.
+      // TODO: Check failed_at before sending? Message about whoops trying again?
+      logger.warn('no messages sent from continueReportbackSubmission');
+      return resolve(this.postReportback(req));
+    });
   }
 
   /**

--- a/app/models/DonorsChooseBot.js
+++ b/app/models/DonorsChooseBot.js
@@ -73,7 +73,7 @@ donorsChooseBotSchema.methods.renderMessage = function (req, msgType) {
     msg = msg.replace('{{url}}', req.donation.proposal_url);
   }
 
-  BotRequest.log(req, 'donorschoosebot', this._id, msgType, msg);
+  BotRequest.log(req, 'donorschoosebot', msgType, msg);
 
   return msg;
 };

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -123,6 +123,7 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
         }
 
         const data = parsePhoenixSignup(currentSignup);
+        logger.debug(`Signup.lookCurrent found signup:${data._id}`);
 
         return model.findOneAndUpdate({ _id: data._id }, data, helpers.upsertOptions())
           .populate('user')
@@ -201,13 +202,13 @@ signupSchema.methods.createDraftReportbackSubmission = function () {
       })
       .then(reportbackSubmission => {
         const submissionId = reportbackSubmission._id;
-        logger.debug(`${logPrefix} created reportback_submission:${submissionId.toString()}`);
+        logger.verbose(`${logPrefix} created reportback_submission:${submissionId.toString()}`);
         signup.draft_reportback_submission = submissionId;
 
         return signup.save();
       })
       .then((updatedSignup) => {
-        logger.debug(`${logPrefix} updated signup:${signup._id}`);
+        logger.verbose(`${logPrefix} updated signup:${signup._id}`);
         stathat.postStat('created draft_reportback_submission');
 
         return resolve(updatedSignup);

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -123,7 +123,7 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
         }
 
         const data = parsePhoenixSignup(currentSignup);
-        logger.debug(`Signup.lookCurrent found signup:${data._id}`);
+        logger.verbose(`Signup.lookCurrent found signup:${data._id}`);
 
         return model.findOneAndUpdate({ _id: data._id }, data, helpers.upsertOptions())
           .populate('user')
@@ -146,8 +146,10 @@ signupSchema.statics.lookupCurrent = function (user, campaign) {
  * @param {User} user - User model.
  * @param {Campaign} campaign - Phoenix Campaign object.
  * @param {string} keyword - Keyword used to trigger Campaign Signup.
+ * @param {number} broadcastId
+ * @return {Promise}
  */
-signupSchema.statics.post = function (user, campaign, keyword) {
+signupSchema.statics.post = function (user, campaign, keyword, broadcastId) {
   const model = this;
   const statName = 'phoenix: POST signups';
 
@@ -169,8 +171,13 @@ signupSchema.statics.post = function (user, campaign, keyword) {
         const data = {
           campaign: campaign.id,
           user: user._id,
-          keyword,
         };
+        if (keyword) {
+          data.keyword = keyword;
+        }
+        if (broadcastId) {
+          data.broadcast_id = broadcastId;
+        }
 
         return model.findOneAndUpdate({ _id: signupId }, data, helpers.upsertOptions()).exec();
       })

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -353,8 +353,7 @@ router.use((req, res, next) => {
     return next();
   }
 
-  // TODO: Pass broadcast_id here too.
-  return Signup.post(req.user, req.campaign, req.keyword)
+  return Signup.post(req.user, req.campaign, req.keyword, req.broadcast_id)
     .then((signup) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
@@ -374,7 +373,7 @@ router.use((req, res, next) => {
     return helpers.sendResponse(res, 500, 'req.signup is undefined');
   }
 
-  logger.info(`user:${req.user._id} campaign:${req.campaign.id} signup:${req.signup._id}`);
+  logger.verbose(`user:${req.user._id} campaign:${req.campaign.id} signup:${req.signup._id}`);
   newrelic.addCustomParameters({ signupId: req.signup._id });
 
   return next();

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -13,7 +13,6 @@ const controller = new CampaignBotController();
 const helpers = require('../../lib/helpers');
 const contentful = require('../../lib/contentful');
 const newrelic = require('newrelic');
-const mobilecommons = require('../../lib/mobilecommons');
 const phoenix = require('../../lib/phoenix');
 const stathat = require('../../lib/stathat');
 const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
@@ -74,8 +73,9 @@ function continueConversationWithMessageType(req, res, messageType) {
  * Sends given message to user to end conversation.
  */
 function endConversationWithMessage(req, res, message) {
-  // TODO: Promisify send_message and return 200 when we know message delivery successful.
-  mobilecommons.send_message(req.user.mobile, message);
+  // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
+  const oip = process.env.MOBILECOMMONS_OIP_AGENTVIEW;
+  req.user.postMobileCommonsProfileUpdate(oip, message);
 
   return helpers.sendResponse(res, 200, message);
 }

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -435,7 +435,10 @@ router.post('/', (req, res, next) => {
   return helpers.sendResponse(res, 500, 'I don\'t know how to respond :(');
 });
 
-
+/**
+ * Send back reply to Reportback conversation.
+ * TODO: Refactor to return continueConversationWithMessageType to DRY.
+ */
 router.post('/', (req, res) => {
   const scope = req;
   // TODO: Add config variable for invalid text input copy.

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -23,8 +23,6 @@ const BotRequest = require('../models/BotRequest');
 const Signup = require('../models/Signup');
 const User = require('../models/User');
 
-const agentViewOip = process.env.MOBILECOMMONS_OIP_AGENTVIEW;
-
 /**
  * Determines if given incomingMessage matches given Gambit command type.
  */
@@ -44,6 +42,35 @@ function isCommand(incomingMessage, commandType) {
 }
 
 /**
+ * Renders message for given messageType, sends it to continue conversation for current campaign.
+ * Assumes we have a loaded req.user and req.campaign.
+ */
+function continueConversationWithMessageType(req, res, messageType) {
+  const scope = req;
+
+  return contentful.renderMessageForPhoenixCampaign(req.campaign, messageType)
+    .then((message) => {
+      scope.replyMessage = helpers.addSenderPrefix(message);
+      // Store current campaign for subsequent messages.
+      scope.user.current_campaign = req.campaignId;
+
+      return scope.user.save();
+    })
+    .then(() => {
+      logger.debug(`saved user:${req.user._id} current_campaign:${req.campaignId}`);
+
+      // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
+      const oip = process.env.MOBILECOMMONS_OIP_CHATBOT;
+      req.user.postMobileCommonsProfileUpdate(oip, scope.replyMessage);
+      stathat.postStat(`campaignbot:${messageType}`);
+      BotRequest.log(req, 'campaignbot', null, messageType, scope.replyMessage);
+
+      return helpers.sendResponse(res, 200, scope.replyMessage);
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+}
+
+/**
  * Sends given message to user to end conversation.
  */
 function endConversationWithMessage(req, res, message) {
@@ -57,6 +84,7 @@ function endConversationWithMessage(req, res, message) {
  * Renders message for given messageType, then sends it to end conversation.
  */
 function endConversationWithMessageType(req, res, messageType) {
+  // TODO: Log botRequest for incoming request / outgoing response.
   contentful.renderMessageForPhoenixCampaign(req.campaign, messageType)
     .then(message => endConversationWithMessage(req, res, helpers.addSenderPrefix(message)))
     .catch(err => helpers.sendErrorResponse(res, err));
@@ -300,89 +328,129 @@ router.use((req, res, next) => {
 });
 
 /**
- * Find or create Signup for our User and Campaign, and reply accordingly.
- * TODO: Split this up into more middleware functions.
+ * Check DS API for existing Signup.
  */
+router.use((req, res, next) => {
+  Signup.lookupCurrent(req.user, req.campaign)
+    .then((signup) => {
+      if (req.timedout) {
+        return helpers.sendTimeoutResponse(res);
+      }
+      if (signup) {
+        req.signup = signup; // eslint-disable-line no-param-reassign
+      }
+
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+});
+
+/**
+ * If Signup wasn't found, post Signup to DS API.
+ */
+router.use((req, res, next) => {
+  if (req.signup) {
+    return next();
+  }
+
+  // TODO: Pass broadcast_id here too.
+  return Signup.post(req.user, req.campaign, req.keyword)
+    .then((signup) => {
+      if (req.timedout) {
+        return helpers.sendTimeoutResponse(res);
+      }
+      req.signup = signup; // eslint-disable-line no-param-reassign
+
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+});
+
+/**
+ * Sanity check: make sure there's a Signup.
+ */
+router.use((req, res, next) => {
+  if (!req.signup) {
+    return helpers.sendResponse(res, 500, 'req.signup is undefined');
+  }
+
+  logger.info(`user:${req.user._id} campaign:${req.campaign.id} signup:${req.signup._id}`);
+  newrelic.addCustomParameters({ signupId: req.signup._id });
+
+  return next();
+});
+
+/**
+ * Check for non-reportback conversation messages first for sending reply message.
+ */
+router.post('/', (req, res, next) => {
+  if (isCommand(req.incoming_message, 'member_support')) {
+    return endConversationWithMessageType(req, res, 'member_support');
+  }
+
+  // If this is a reportback conversation, skip to our next middleware.
+  if (req.signup.draft_reportback_submission || isCommand(req.incoming_message, 'reportback')) {
+    return next();
+  }
+
+  // If member has completed this campaign:
+  if (req.signup.reportback) {
+    // And it's the beginning of a conversation:
+    if (req.keyword || req.broadcast_id) {
+      return continueConversationWithMessageType(req, res, 'menu_completed');
+    }
+    // Otherwise member didn't text back Reportback or Member Support commands.
+    return continueConversationWithMessageType(req, res, 'invalid_cmd_completed');
+  }
+
+  if (req.keyword || req.broadcast_id) {
+    return continueConversationWithMessageType(req, res, 'menu_signedup_gambit');
+  }
+
+  return continueConversationWithMessageType(req, res, 'invalid_cmd_signedup');
+});
+
+/**
+ * Determine message type for reply based on current Reportback conversation state.
+ */
+router.post('/', (req, res, next) => {
+  if (req.signup.draft_reportback_submission) {
+    logger.debug(`draft_reportback_submission:${req.signup.draft_reportback_submission._id}`);
+
+    return controller.continueReportbackSubmission(req)
+      .then((messageType) => {
+        req.msg_type = messageType; // eslint-disable-line no-param-reassign
+        return next();
+      });
+  }
+
+  if (isCommand(req.incoming_message, 'reportback')) {
+    return req.signup.createDraftReportbackSubmission()
+      .then(() => {
+        req.msg_type = 'ask_quantity'; // eslint-disable-line no-param-reassign
+        return next();
+      });
+  }
+
+  // This should never get called, but in case it does:
+  return helpers.sendResponse(res, 500, 'I don\'t know how to respond :(');
+});
+
+
 router.post('/', (req, res) => {
   const scope = req;
+  // TODO: Add config variable for invalid text input copy.
+  scope.msg_prefix = 'Sorry, I didn\'t understand that.\n\n';
 
-  return Signup.lookupCurrent(scope.user, scope.campaign)
-    .then((currentSignup) => {
-      if (currentSignup) {
-        logger.debug(`Signup.lookupCurrent found signup:${currentSignup._id}`);
+  if (scope.msg_type === 'invalid_caption') {
+    scope.msg_type = 'ask_caption';
+  } else if (scope.msg_type === 'invalid_why_participated') {
+    scope.msg_type = 'ask_why_participated';
+  } else {
+    scope.msg_prefix = '';
+  }
 
-        return currentSignup;
-      }
-      logger.debug('Signup.lookupCurrent not find signup');
-
-      return Signup.post(scope.user, scope.campaign, scope.keyword);
-    })
-    .then((signup) => {
-      logger.info(`loaded signup:${signup._id.toString()}`);
-      scope.signup = signup;
-      newrelic.addCustomParameters({ signupId: signup._id });
-
-      if (!scope.signup) {
-        // TODO: Handle this edge-case.
-        logger.error('signup undefined');
-        return false;
-      }
-
-      if (scope.broadcast_id) {
-        // TODO: Add new parameter for broadcast_id to Signup post instead of saving here.
-        scope.signup.broadcast_id = scope.broadcast_id;
-        scope.signup.save().catch((err) => logger.error('Error saving broadcast id', err.message));
-      }
-
-      if (isCommand(scope.incoming_message, 'member_support')) {
-        scope.cmd_member_support = true;
-        scope.oip = agentViewOip;
-        return 'member_support';
-      }
-
-      if (scope.signup.draft_reportback_submission) {
-        logger.debug(`draft_reportback_submission:${scope.signup.draft_reportback_submission._id}`);
-        return controller.continueReportbackSubmission(scope);
-      }
-
-      if (isCommand(scope.incoming_message, 'reportback')) {
-        return scope.signup.createDraftReportbackSubmission().then(() => 'ask_quantity');
-      }
-
-      if (scope.signup.reportback) {
-        if (scope.keyword || scope.broadcast_id) {
-          return 'menu_completed';
-        }
-        // If we're this far, member didn't text back Reportback or Member Support commands.
-        return 'invalid_cmd_completed';
-      }
-
-      if (scope.keyword || scope.broadcast_id) {
-        return 'menu_signedup_gambit';
-      }
-
-      return 'invalid_cmd_signedup';
-    })
-    .then((msgType) => {
-      // This is hacky, CampaignBotController.postReportback returns error that isn't caught.
-      // TODO: Clean this up when ready to take on https://github.com/DoSomething/gambit/issues/744.
-      if (msgType instanceof Error) {
-        throw new Error(msgType.message);
-      }
-
-      scope.msg_type = msgType;
-      // TODO: Add config variable for invalid text input copy.
-      scope.msg_prefix = 'Sorry, I didn\'t understand that.\n\n';
-
-      if (scope.msg_type === 'invalid_caption') {
-        scope.msg_type = 'ask_caption';
-      } else if (scope.msg_type === 'invalid_why_participated') {
-        scope.msg_type = 'ask_why_participated';
-      } else {
-        scope.msg_prefix = '';
-      }
-      return contentful.renderMessageForPhoenixCampaign(scope.campaign, scope.msg_type);
-    })
+  return contentful.renderMessageForPhoenixCampaign(scope.campaign, scope.msg_type)
     .then((renderedMessage) => {
       scope.response_message = `${scope.msg_prefix} ${renderedMessage}`;
       newrelic.addCustomParameters({ gambitResponseMessageType: scope.msg_type });


### PR DESCRIPTION
#### What's this PR do?
* Creates middleware that finds, creates Signups and checks for timeouts
* Adds `continueConversationWithMessageType` function to render a message, deliver it via Mobile Commons `profile_update`, and return a success response
* Changes `endConversationWithMessage` to post to Mobile Commons `profile_upate ` so Agents using Agentview know the point of entry was from the Campaignbot Campaign (vs Master Campaign). Refs [Slack thread](https://dosomething.slack.com/archives/C1V0M6RPE/p1492109988626004?thread_ts=1492104823.164899&cid=C1V0M6RPE) with @jamjensen 
* Refactors `BotRequest.log` to remove the `bot_id` field, an unused relic from the Gambit Jr. days

#### How should this be reviewed?
📲 👀 

#### Any background context you want to provide?
This adds the most important timeout check, finding a Signup. Last items to take care of before we can close out #849 is adding to `routes/campaigns`.

Also next up -- this refactory puts in a great place to finally close out #744 next

#### Relevant tickets
#849, #744, #824 

#### Checklist
- [x] Tested on staging.
