### PR TITLE
Cleanup Signup error responses, deprecate NotFoundError class

### DIFF
--- a/app/exceptions/NotFoundError.js
+++ b/app/exceptions/NotFoundError.js
@@ -1,5 +1,0 @@
-'use strict';
-
-class NotFoundError extends Error {}
-
-module.exports = NotFoundError;

--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -8,7 +8,6 @@ const Promise = require('bluebird');
 const logger = require('winston');
 
 const ReportbackSubmission = require('./ReportbackSubmission');
-const NotFoundError = require('../exceptions/NotFoundError');
 const helpers = require('../../lib/helpers');
 const phoenix = require('../../lib/phoenix');
 const stathat = require('../../lib/stathat');
@@ -84,14 +83,8 @@ signupSchema.statics.lookupById = function (id) {
       .then(signupDoc => resolve(signupDoc))
       .catch(err => {
         stathat.postStatWithError(statName, err);
-        if (err.status === 404) {
-          const msg = `Signup ${id} not found.`;
-          const notFoundError = new NotFoundError(msg);
-          return reject(notFoundError);
-        }
-
         const scope = err;
-        scope.message = `Signup.lookupById error:${err.message}`;
+        scope.message = `Signup.lookupById:${id} error:${err.message}`;
         return reject(scope);
       });
   });

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -49,7 +49,7 @@ router.use((req, res, next) => {
       req.signup = signup; // eslint-disable-line no-param-reassign
       return next();
     })
-    .catch(err => helpers.sendResponse(res, 500, err.message));
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 /**
@@ -68,7 +68,7 @@ router.use((req, res, next) => {
       req.campaign = phoenixCampaign; // eslint-disable-line no-param-reassign
       return next();
     })
-    .catch(err => helpers.sendResponse(res, 500, err.message));
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 /**
@@ -86,7 +86,7 @@ router.use((req, res, next) => {
       }
       return next();
     })
-    .catch(err => helpers.sendResponse(res, 500, err.message));
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 /**
@@ -104,7 +104,7 @@ router.use((req, res, next) => {
       req.user = user; // eslint-disable-line no-param-reassign
       return next();
     })
-    .catch(err => helpers.sendResponse(res, 500, err.message));
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 /**
@@ -119,7 +119,7 @@ router.use((req, res, next) => {
       req.signupMessage = helpers.addSenderPrefix(message); // eslint-disable-line no-param-reassign
       return next();
     })
-    .catch(err => helpers.sendResponse(res, 500, err.message));
+    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
 /**
@@ -147,7 +147,7 @@ router.post('/', (req, res) => {
 
     return helpers.sendResponse(res, 200, req.signupMessage);
   } catch (err) {
-    return helpers.sendResponse(res, 500, err.message);
+    return helpers.sendErrorResponse(res, err);
   }
 });
 


### PR DESCRIPTION
#### What's this PR do?
* Returns an error status code if we have one in the **POST** `/signups` response by using `helpers.sendErrorResponse`
   * Middleware refactory for Signups took place in #852, `helpers.sendErrorResponse` was introduced in #853, which forgot to go back and cleanup our Signup errors

* Deprecates the `NotFoundError` class. The custom `app/exceptions` were put in place to use filtered catches by our monster Promise chains, which we're looking to deprecate by splitting into smaller middleware functions (#824). If we're handling an error as it comes up, we can use `helpers.sendErrorResponse` to check for a HTTP status and send it back with the Gambit response.

#### How should this be reviewed?
* **POST** `/signups` with a Signup id that doesn't exist. Confirm a 404 is sent back, not a 500
* **POST** `/campaigns/:id/message` with a Campaign id that doesn't exist. Confirm a 404 is sent back, not a 500

#### Any background context you want to provide?
Next up is closing out #849 for good by introducing timedout checks into the Campaigns endpoint. Noticed some cleanup we could do in Signups when posting to a Signup ID that didn't exist (got a 500 back instead of expected 404)

#### Checklist
- [x] Tested on staging.
