### PR TITLE
New Relic parameter for Gambit Error Message

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,7 @@
  */
 const crypto = require('crypto');
 const logger = require('winston');
+const newrelic = require('newrelic');
 const contentful = require('./contentful');
 const stathat = require('./stathat');
 
@@ -187,6 +188,7 @@ module.exports.sendErrorResponse = function (res, err) {
   if (!status) {
     status = 500;
   }
+  newrelic.addCustomParameters({ gambitErrorMessage: err.message });
 
   return this.sendResponse(res, status, err.message);
 };

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -12,6 +12,7 @@ const httpMocks = require('node-mocks-http');
 const contentful = require('../../lib/contentful.js');
 const stathat = require('../../lib/stathat');
 const crypto = require('crypto');
+const newrelic = require('newrelic');
 const logger = require('winston');
 
 // Module to test
@@ -43,6 +44,7 @@ test.beforeEach((t) => {
     .returns(Promise.resolve([]));
   sandbox.stub(logger, 'error');
   sandbox.stub(logger, 'debug');
+  sandbox.stub(newrelic, 'addCustomParameters');
   sandbox.stub(stathat, 'postStat');
   sandbox.stub(crypto, 'createHmac').returns(cryptoCreateHmacStub);
 
@@ -217,6 +219,7 @@ test('sendErrorResponse', (t) => {
   helpers.sendErrorResponse(t.context.res, { /* Error Object */ });
 
   helpers.sendResponse.should.have.been.called;
+  newrelic.addCustomParameters.should.have.been.called;
   // TODO: Use calledWithExactly when testing specific errors
   helpers.sendResponse.should.have.been.calledWith(t.context.res, 500);
 });


### PR DESCRIPTION
#### What's this PR do?
Logs a new `gambitErrorMessage ` custom parameter in New Relic from `helpers.sendErrorResponse`.

#### How should this be reviewed?
Replicate #881 and verify the error message appears in New Relic:
<img width="434" alt="screen shot 2017-05-02 at 9 50 34 am" src="https://cloud.githubusercontent.com/assets/1236811/25628974/d52be5a8-2f1c-11e7-8adb-72954fe2ea61.png">

#### Relevant tickets
Fixes #880 

#### Checklist
- [x] Tested on staging.
