### PR TITLE
Bug fix in POST Signups 

### DIFF
--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -49,7 +49,9 @@ router.use((req, res, next) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
       }
+
       req.signup = signup; // eslint-disable-line no-param-reassign
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));
@@ -128,7 +130,9 @@ router.use((req, res, next) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
       }
+
       req.signupMessage = helpers.addSenderPrefix(message); // eslint-disable-line no-param-reassign
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -4,6 +4,7 @@ const express = require('express');
 
 const router = express.Router(); // eslint-disable-line new-cap
 const logger = require('winston');
+const newrelic = require('newrelic');
 
 const contentful = require('../../lib/contentful');
 const helpers = require('../../lib/helpers');
@@ -28,6 +29,7 @@ router.use((req, res, next) => {
     return helpers.sendUnproccessibleEntityResponse(res, 'Missing required source.');
   }
 
+  newrelic.addCustomParameters({ signupId: req.body.id });
   const source = req.body.source;
   if (source === process.env.DS_API_POST_SOURCE) {
     const msg = `CampaignBot only sends confirmation when source not equal to ${source}.`;
@@ -62,11 +64,15 @@ router.use((req, res, next) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
       }
+
       if (phoenix.isClosedCampaign(phoenixCampaign)) {
         const err = new ClosedCampaignError(phoenixCampaign);
         return helpers.sendUnproccessibleEntityResponse(res, err.message);
       }
+
       req.campaign = phoenixCampaign; // eslint-disable-line no-param-reassign
+      newrelic.addCustomParameters({ campaignId: req.campaign.id });
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));
@@ -81,10 +87,12 @@ router.use((req, res, next) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
       }
+
       if (keywords.length === 0) {
         const msg = `Campaign ${req.campaign.id} does not have any Gambit keywords.`;
-        return helpers.sendUnproccessibleEntityResponse(msg);
+        return helpers.sendUnproccessibleEntityResponse(res, msg);
       }
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));
@@ -102,7 +110,10 @@ router.use((req, res, next) => {
       if (!user.mobile) {
         return helpers.sendUnproccessibleEntityResponse(res, 'Missing required user.mobile.');
       }
+
       req.user = user; // eslint-disable-line no-param-reassign
+      newrelic.addCustomParameters({ userId: req.user.id });
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));


### PR DESCRIPTION
#### What's this PR do?
* Fixes #885 by passing our Express `res` variable to a `sendUnproccessibleEntityResponse` call.
* Adds New Relic custom parameters to help debug errors logged in New Relic

#### How should this be reviewed?
This was happening for the scenario when Quicksilver is posting Signups for Campaigns that no longer have keywords published. I've unpublished SHOWERBOT to verify I get a 422 back instead a 500 with `res.status is not a function`

#### Any background context you want to provide?
The good news here is we didn't want to send Extneral Signup Messages in this case anyway, because the DS Campaign is no longer available on Gambit. Minorly bad news is that it means Quicksilver cache should be restarted? cc @jamjensen @sergii-tkachenko 

#### Relevant tickets
Fixes #885 

#### Checklist
- [x] Tested on staging.
