### PR TITLE
Remove ID's from some error messages

### DIFF
--- a/app/models/Signup.js
+++ b/app/models/Signup.js
@@ -84,7 +84,7 @@ signupSchema.statics.lookupById = function (id) {
       .catch((err) => {
         stathat.postStatWithError(statName, err);
         const scope = err;
-        scope.message = `Signup.lookupById:${id} error:${err.message}`;
+        scope.message = `Signup.lookupById error:${err.message}`;
         return reject(scope);
       });
   });

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -217,7 +217,6 @@ router.post('/:id/message', (req, res, next) => {
     if (err.response) {
       logger.error(err.response.error);
     }
-    stathat.postStatWithError(statName, err);
 
     return helpers.sendErrorResponse(res, err);
   };

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -182,36 +182,45 @@ router.post('/:id/message', (req, res, next) => {
 });
 
 /**
- * Render our campaign message to deliver and post it to Mobile Commons.
+ * Render our campaign message to send.
  */
-router.post('/:id/message', (req, res) => {
-  const statName = `campaignbot:${req.messageType}`;
-
-  return contentful.renderMessageForPhoenixCampaign(req.campaign, req.messageType)
+router.post('/:id/message', (req, res, next) => {
+  contentful.renderMessageForPhoenixCampaign(req.campaign, req.messageType)
     .then((message) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
       }
-      const messageBody = helpers.addSenderPrefix(message);
-      mobilecommons.send_message(req.phone, messageBody);
-      const msg = `Sent messageType:${req.messageType} campaign:${req.campaignId} ` +
-                  `phone:${req.phone}`;
-      logger.info(msg);
-      stathat.postStat(statName);
 
-      return helpers.sendResponse(res, 200, messageBody);
+      req.messageBody = helpers.addSenderPrefix(message); // eslint-disable-line no-param-reassign
+
+      return next();
     })
-    .catch((err) => {
-      // Check for response object that Mobile Commons may send:
-      if (err.response) {
-        logger.error(err.response.error);
-      }
-      stathat.postStatWithError(statName, err);
-      const scope = err;
-      scope.message = `Error sending text to phone:${req.phone}: ${err.message}`;
+    .catch(err => helpers.sendErrorResponse(res, err));
+});
 
-      return helpers.sendErrorResponse(res, err);
-    });
+/**
+ * Post to Mobile Commons to send the message.
+ */
+router.post('/:id/message', (req, res, next) => {
+  const statName = `campaignbot:${req.messageType}`;
+
+  try {
+    mobilecommons.send_message(req.phone, req.messageBody);
+    const msg = `Sent messageType:${req.messageType} campaign:${req.campaignId} ` +
+                `phone:${req.phone}`;
+    logger.info(msg);
+    stathat.postStat(statName);
+
+    return helpers.sendResponse(res, 200, req.messageBody);
+  } catch (err) {
+    // Check for response object that Mobile Commons may send:
+    if (err.response) {
+      logger.error(err.response.error);
+    }
+    stathat.postStatWithError(statName, err);
+
+    return helpers.sendErrorResponse(res, err);
+  };
 });
 
 module.exports = router;

--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -201,7 +201,7 @@ router.post('/:id/message', (req, res, next) => {
 /**
  * Post to Mobile Commons to send the message.
  */
-router.post('/:id/message', (req, res, next) => {
+router.post('/:id/message', (req, res) => {
   const statName = `campaignbot:${req.messageType}`;
 
   try {
@@ -219,7 +219,7 @@ router.post('/:id/message', (req, res, next) => {
     }
 
     return helpers.sendErrorResponse(res, err);
-  };
+  }
 });
 
 module.exports = router;

--- a/lib/phoenix.js
+++ b/lib/phoenix.js
@@ -46,7 +46,7 @@ module.exports.fetchCampaign = function (campaignId) {
       .then(phoenixCampaign => resolve(phoenixCampaign))
       .catch((err) => {
         const scope = err;
-        scope.message = `phoenix.fetchCampaign:${campaignId} ${err.message}`;
+        scope.message = `phoenix.fetchCampaign ${err.message}`;
 
         return reject(scope);
       });


### PR DESCRIPTION
#### What's this PR do?
* Removes unique ID's for some error messages to cleanup our Stathat stats.
* Adds a middleware function to the `/campaigns/:id/message` router to separate error handling logic of rendering message vs sending message

#### How should this be reviewed?
Post to `/campaign/6620/message` locally with types:
* `scheduled_relative_to_reportback_date` - Should return a 422 and post stat `'gambit-dev - 422: Contentful msgType:scheduled_relative_to_reportback_date is not defined for default Campaign.'`
* `scheduled_relative_to_signup_date` - Should return a 200 and post stat 'gambit-dev - campaignbot:scheduled_relative_to_signup_date

#### Any background context you want to provide?
I've been clearing out all of the stats with phone numbers by manually deleting them -- you can peek at quite a [few in the trash while they're there for the next 48 hours](https://www.stathat.com/v/stats/trash).

#### Relevant tickets
Fixes #888 

#### Checklist
- [x] Tested on staging.
