### PR TITLE
Adds Dashbot analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ NEW_RELIC_LOGGING_LEVEL=info
 STATHAT_APP_NAME=gambit-dev
 STATHAT_EZ_KEY=puppet.sloth@dosomething.org
 
+DASHBOT_API_KEY=totallysecret
+
 GAMBIT_JR_API_BASEURI=http://dev-gambit-jr.pantheonsite.io/wp-json/wp/v2/
 DONORSCHOOSE_API_BASEURI=https://qa.donorschoose.org
 DONORSCHOOSE_API_KEY=totallysecret

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -129,7 +129,18 @@ userSchema.methods.postMobileCommonsProfileUpdate = function (oip, msgTxt) {
   return mobilecommons.profile_update(this.mobilecommons_id, this.mobile, oip, data);
 };
 
+/**
+ * Posts given messageText to the Dashbot API with given dashbotMessageType.
+ * @see https://www.dashbot.io/sdk/generic.
+ *
+ * @param {number} dashbotMessageType - Expected values: 'incoming' | 'outgoing'
+ * @param {string} messageText - text to track in Dashbot
+ */
 userSchema.methods.postDashbot = function (dashbotMessageType, messageText) {
+  if (!process.env.DASHBOT_API_KEY) {
+    return logger.warn('DASHBOT_API_KEY undefined');
+  }
+
   const logMessage = `user.postDashbot:${dashbotMessageType} ${this._id}:${messageText}`;
   logger.debug(logMessage);
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -90,6 +90,7 @@ function continueConversationWithMessageType(req, res, messageType) {
 
       // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
       req.user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_CHATBOT, replyMessage);
+      req.user.postDashbot('outgoing', replyMessage);
 
       stathat.postStat(`campaignbot:${messageType}`);
       BotRequest.log(req, 'campaignbot', messageType, replyMessage);
@@ -105,6 +106,7 @@ function continueConversationWithMessageType(req, res, messageType) {
 function endConversationWithMessage(req, res, message) {
   // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
   req.user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_AGENTVIEW, message);
+  req.user.postDashbot('outgoing', message);
 
   return helpers.sendResponse(res, 200, message);
 }
@@ -244,6 +246,22 @@ router.use((req, res, next) => {
       return next();
     })
    .catch(err => helpers.sendErrorResponse(res, err));
+});
+
+router.use((req, res, next) => {
+  let dashbotLog = '';
+  if (req.keyword) {
+    dashbotLog = `keyword:${req.keyword} `;
+  }
+  if (req.incoming_image_url) {
+    dashbotLog = `${dashbotLog}(image) `;
+  }
+  if (req.incoming_message) {
+    dashbotLog = `${dashbotLog}${req.incoming_message}`;
+  }
+
+  req.user.postDashbot('incoming', dashbotLog);
+  next();
 });
 
 /**

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -90,7 +90,7 @@ function continueConversationWithMessageType(req, res, messageType) {
 
       // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
       req.user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_CHATBOT, replyMessage);
-      req.user.postDashbot('outgoing', replyMessage);
+      req.user.postDashbotOutgoing(messageType);
 
       stathat.postStat(`campaignbot:${messageType}`);
       BotRequest.log(req, 'campaignbot', messageType, replyMessage);
@@ -106,7 +106,6 @@ function continueConversationWithMessageType(req, res, messageType) {
 function endConversationWithMessage(req, res, message) {
   // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
   req.user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_AGENTVIEW, message);
-  req.user.postDashbot('outgoing', message);
 
   return helpers.sendResponse(res, 200, message);
 }
@@ -118,6 +117,7 @@ function endConversationWithMessageType(req, res, messageType) {
   renderMessageForMessageType(req, messageType)
     .then((message) => {
       BotRequest.log(req, 'campaignbot', messageType, message);
+      req.user.postDashbotOutgoing(messageType);
 
       return endConversationWithMessage(req, res, message);
     })
@@ -260,7 +260,7 @@ router.use((req, res, next) => {
     dashbotLog = `${dashbotLog}${req.incoming_message}`;
   }
 
-  req.user.postDashbot('incoming', dashbotLog);
+  req.user.postDashbotIncoming(dashbotLog);
   next();
 });
 
@@ -289,6 +289,7 @@ router.use((req, res, next) => {
 
         const replyMessage = helpers.addSenderPrefix(broadcast.fields.declinedMessage);
         BotRequest.log(req, 'broadcast', 'prompt_declined', replyMessage);
+        req.user.postDashbotOutgoing('broadcast_declined');
 
         return endConversationWithMessage(req, res, replyMessage);
       }

--- a/app/routes/signups.js
+++ b/app/routes/signups.js
@@ -14,6 +14,8 @@ const ClosedCampaignError = require('../exceptions/ClosedCampaignError');
 const Signup = require('../models/Signup');
 const User = require('../models/User');
 
+const OUTGOING_MESSAGE_TYPE = 'menu_signedup_external';
+
 /**
  * Validate required body parameters.
  */
@@ -125,7 +127,7 @@ router.use((req, res, next) => {
  * Render the External Signup Message.
  */
 router.use((req, res, next) => {
-  contentful.renderMessageForPhoenixCampaign(req.campaign, 'menu_signedup_external')
+  contentful.renderMessageForPhoenixCampaign(req.campaign, OUTGOING_MESSAGE_TYPE)
     .then((message) => {
       if (req.timedout) {
         return helpers.sendTimeoutResponse(res);
@@ -160,6 +162,7 @@ router.post('/', (req, res) => {
   try {
     const oip = process.env.MOBILECOMMONS_OIP_CHATBOT;
     req.user.postMobileCommonsProfileUpdate(oip, req.signupMessage);
+    req.user.postDashbotOutgoing(OUTGOING_MESSAGE_TYPE);
 
     return helpers.sendResponse(res, 200, req.signupMessage);
   } catch (err) {


### PR DESCRIPTION
#### What's this PR do?
Posts incoming and outgoing chatbot messages to Dashbot:
* Outgoing messages are tracked as the Gambit message type (e.g. `ask_photo`, `campaign_closed`, `menu_completed`)
* Incoming messages are tracked with `keyword:[keyword` if they contain a keyword, `(image)` if they contain an image, as well as whatever text a member texts in.

#### How should this be reviewed?
To test locally, add the Dashbot API key for Gambit Local and check its live feed to verify incoming/outgoing messages.
To test Thor, text in a Thor keyword and check the live feed of the Gambit Thor bot to verify incoming/outgoing messages.


#### Any background context you want to provide?
Here are some example screenshots from testing with Gambit Local:

<img width="1090" alt="screen shot 2017-05-05 at 10 49 25 am" src="https://cloud.githubusercontent.com/assets/1236811/25757767/b209bc74-3180-11e7-98ba-f7bfa27857fe.png">
<img width="1083" alt="screen shot 2017-05-05 at 10 50 00 am" src="https://cloud.githubusercontent.com/assets/1236811/25757771/b57fcf7e-3180-11e7-8cf4-84ca7c7b221a.png">
<img width="1095" alt="screen shot 2017-05-05 at 10 50 12 am" src="https://cloud.githubusercontent.com/assets/1236811/25757773/ba1aecd0-3180-11e7-8da8-2304d5f84f0c.png">


#### Checklist
- [ ] Tested on staging.
