### PR TITLE
Add more outgoing messages to analytics

### DIFF
--- a/app/routes/campaigns.js
+++ b/app/routes/campaigns.js
@@ -16,6 +16,7 @@ const helpers = require('../../lib/helpers');
 const mobilecommons = rootRequire('lib/mobilecommons');
 const phoenix = require('../../lib/phoenix');
 const stathat = require('../../lib/stathat');
+const User = require('../models/User');
 
 /**
  * Queries Phoenix, Contentful, and Mongo to render an object for a given Campaign id.
@@ -192,6 +193,23 @@ router.post('/:id/message', (req, res, next) => {
       }
 
       req.messageBody = helpers.addSenderPrefix(message); // eslint-disable-line no-param-reassign
+
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
+});
+
+/**
+ * Load the user to track outgoing message.
+ */
+router.post('/:id/message', (req, res, next) => {
+  User.lookup('mobile', req.body.phone)
+    .then((user) => {
+      if (req.timedout) {
+        return helpers.sendTimeoutResponse(res);
+      }
+
+      user.postDashbotOutgoing(req.messageType);
 
       return next();
     })

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -267,7 +267,7 @@ router.use((req, res, next) => {
     dashbotLog = `${dashbotLog}${req.incoming_message}`;
   }
 
-  req.user.postDashbotIncoming(dashbotLog);
+  req.user.postDashbotIncoming(dashbotLog.toLowerCase());
   next();
 });
 

--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -248,7 +248,14 @@ router.use((req, res, next) => {
    .catch(err => helpers.sendErrorResponse(res, err));
 });
 
+/**
+ * Track incoming message (and outgoing, if this is a reply to a broadcast).
+ */
 router.use((req, res, next) => {
+  if (req.broadcast_id) {
+    req.user.postDashbotOutgoing('broadcast');
+  }
+
   let dashbotLog = '';
   if (req.keyword) {
     dashbotLog = `keyword:${req.keyword} `;


### PR DESCRIPTION
#### What's this PR do?
Adds broadcast and scheduled message types to our outgoing message analytics, better indicating our ratio of incoming / outgoing Gambit messages. 

#### How should this be reviewed?
* Post to `/campaigns/:id/message` with type `scheduled_relative_to_signup_date`, verify that `scheduled_relative_to_signup_date` is tracked as an outgoing message in analytics
* Post to `/chatbot` and pass a `broadcast_id` to verify that `broadcast` is tracked as an outgoing message in analytics

#### Any background context you want to provide?
We're loading a Northstar User in the Campaign Message router to track the analytics by User ID. It's a slight performance hit, but it feels like a better tradeoff than storing our users by their phone numbers in 3rd party analytics services like Dashbot (or potentially [Botanalytics](https://github.com/DoSomething/gambit/pull/891#issuecomment-300216309))

#### Relevant tickets
* Relative Reminders as outgoing message -- https://github.com/DoSomething/gambit/pull/891#issuecomment-299538306
* Broadcasts as outgoing message -- https://github.com/DoSomething/gambit/pull/891#issuecomment-300320978

#### Checklist
- [ ] Tested on staging.

