### PR TITLE
Track messageType in stathat when ending conversations

### DIFF
--- a/app/routes/chatbot.js
+++ b/app/routes/chatbot.js
@@ -118,6 +118,7 @@ function endConversationWithMessageType(req, res, messageType) {
   renderMessageForMessageType(req, messageType)
     .then((message) => {
       BotRequest.log(req, 'campaignbot', messageType, message);
+      stathat.postStat(`campaignbot:${messageType}`);
       req.user.postDashbotOutgoing(messageType);
 
       return endConversationWithMessage(req, res, message);
@@ -135,6 +136,7 @@ function endConversationWithError(req, res, error) {
     .then((message) => {
       // todo: Promisify this POST request and only send back Gambit 200 on profile_update success.
       req.user.postMobileCommonsProfileUpdate(process.env.MOBILECOMMONS_OIP_AGENTVIEW, message);
+      stathat.postStat(`campaignbot:${messageType}`);
       req.user.postDashbotOutgoing(messageType);
 
       newrelic.addCustomParameters({ blinkSuppressRetry: true });


### PR DESCRIPTION
#### What's this PR do?
* Adds missing `campaignbot:[messageType` stats to Stathat when ending converastion (`campaign_closed, `error_occurred`). Missed this in #910.

#### How should this be reviewed?
* Replicate steps in #910 to trigger an Error Occurred Message, verify stathat stat is created.

#### Checklist
- [ ] Tested on staging.
