### PR TITLE
README updates + Rogue wiki

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,10 +1,15 @@
 [![wercker status](https://app.wercker.com/status/3e08a89169eeafef8ec020a9ceafe204/s/master "wercker status")](https://app.wercker.com/project/byKey/3e08a89169eeafef8ec020a9ceafe204) [![codecov](https://codecov.io/gh/DoSomething/gambit-campaigns/branch/master/graph/badge.svg)](https://codecov.io/gh/DoSomething/gambit-campaigns)
 
 # Gambit Campaigns
-Gambit Campaigns is a [Gambit Conversations](https://github.com/dosomething/gambit-conversations) microservice used for:
-* Receiving inbound Gambit Conversation messages and posting User Campaign activity to [Rogue](https://github.com/dosomething/rogue)
-* Querying Contentful to provide a list of Campaigns and Signup keywords currently available on Gambit
-* Querying Contentful to provide Gambit message content for an individual Campaign
+
+Gambit Campaigns is a [Gambit Conversations](https://github.com/dosomething/gambit-conversations) microservice for:
+
+* Storing User Campaign activity from an inbound message, and posting it to [Rogue](https://github.com/dosomething/gambit-campaigns/wiki/rogue).
+
+* Querying Contentful for a list of active Keywords and Campaigns available running on Gambit.
+
+* Querying [Phoenix Ashes](https://github.com/DoSomething/gambit-campaigns/wiki/Admin#available-variables) for Campaign data used in Gambit message templates.
+
 
 Gambit Campaigns is built using [Express](http://expressjs.com/) and [MongoDB](https://www.mongodb.com).
 
@@ -28,6 +33,6 @@ Gambit Campaigns is built using [Express](http://expressjs.com/) and [MongoDB](h
 
 
 ### License
-&copy;2017 DoSomething.org. Gambit Campaigns is free software, and may be redistributed under the terms specified
+&copy;2018 DoSomething.org. Gambit Campaigns is free software, and may be redistributed under the terms specified
 in the [LICENSE](https://github.com/DoSomething/gambit-campaigns/blob/dev/LICENSE) file. The name and logo for
 DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/.github/README.md
+++ b/.github/README.md
@@ -11,7 +11,8 @@ Gambit Campaigns is a [Gambit Conversations](https://github.com/dosomething/gamb
 * Querying [Phoenix Ashes](https://github.com/DoSomething/gambit-campaigns/wiki/Admin#available-variables) for Campaign data used in Gambit message templates.
 
 
-Gambit Campaigns is built using [Express](http://expressjs.com/) and [MongoDB](https://www.mongodb.com).
+Gambit Campaigns is built using [Express](http://expressjs.com/), [MongoDB](https://www.mongodb.com), and [Redis](https://redis.io/).
+
 
 ### Installation
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 DoSomething.org
+Copyright (c) 2018 DoSomething.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
#### What's this PR do?
Updates README description with link to the new[ Rogue wiki page](https://github.com/dosomething/gambit-campaigns/wiki/rogue), detailing the endpoints Gambit consumes.

#### How should this be reviewed?
👓 📖 

#### Any background context you want to provide?
These are the tech details @ngjo asked for when making a very handy flowchart of Gambit Conversation of Campaign signup and completion messaging. 

@ngjo - could we maybe link to the flowchart in this [repo's wiki homepage](https://github.com/DoSomething/gambit-campaigns/wiki)? What's there is essentially a reptition of the README anyway and could be nuked. There used to be a [flowchart](https://cloud.githubusercontent.com/assets/1236811/26090808/13902bd4-39bc-11e7-8b91-44e0994372c8.png) in that wiki page, but it's outdated - this repo no longer handles Northstar User integration.

#### Relevant tickets
Fixes #1016 


