### PR TITLE
Adds faqAnswer type to deprecate message type

### DIFF
--- a/config/lib/helpers/contentfulEntry.js
+++ b/config/lib/helpers/contentfulEntry.js
@@ -99,6 +99,10 @@ module.exports = {
     defaultTopicTrigger: {
       type: 'defaultTopicTrigger',
     },
+    faqAnswer: {
+      type: 'faqAnswer',
+    },
+    // To be deprecated by faqAnswer
     message: {
       type: 'message',
     },

--- a/lib/helpers/contentfulEntry.js
+++ b/lib/helpers/contentfulEntry.js
@@ -223,8 +223,9 @@ function isLegacyBroadcast(contentfulEntry) {
  * @param {Object} contentfulEntry
  * @return {Boolean}
  */
-function isMessage(contentfulEntry) {
-  return contentful.isContentType(contentfulEntry, config.contentTypes.message.type);
+function isFaqAnswer(contentfulEntry) {
+  return [config.contentTypes.message.type, config.contentTypes.faqAnswer.type]
+    .includes(contentful.getContentTypeFromContentfulEntry(contentfulEntry));
 }
 
 /**
@@ -260,7 +261,7 @@ module.exports = {
   isBroadcastable,
   isDefaultTopicTrigger,
   isLegacyBroadcast,
-  isMessage,
+  isFaqAnswer,
   isTransitionable,
   isTransitionTemplate,
   parseContentfulEntry,

--- a/lib/helpers/defaultTopicTrigger.js
+++ b/lib/helpers/defaultTopicTrigger.js
@@ -91,7 +91,7 @@ async function parseDefaultTopicTrigger(contentfulEntry) {
     return data;
   }
 
-  if (helpers.contentfulEntry.isMessage(responseEntry)) {
+  if (helpers.contentfulEntry.isFaqAnswer(responseEntry)) {
     data.reply = contentful.getTextFromMessage(responseEntry);
     return data;
   }

--- a/test/lib/lib-helpers/contentfulEntry.test.js
+++ b/test/lib/lib-helpers/contentfulEntry.test.js
@@ -19,6 +19,7 @@ const autoReplyFactory = require('../../utils/factories/contentful/autoReply');
 const autoReplyBroadcastFactory = require('../../utils/factories/contentful/autoReplyBroadcast');
 const autoReplyTransitionFactory = require('../../utils/factories/contentful/autoReplyTransition');
 const defaultTopicTriggerFactory = require('../../utils/factories/contentful/defaultTopicTrigger');
+const faqAnswerFactory = require('../../utils/factories/contentful/faqAnswer');
 const messageFactory = require('../../utils/factories/contentful/message');
 // Parsed factories
 const broadcastFactory = require('../../utils/factories/broadcast');
@@ -200,10 +201,11 @@ test('isDefaultTopicTrigger returns whether content type is defaultTopicTrigger'
   t.falsy(contentfulEntryHelper.isDefaultTopicTrigger(messageEntry));
 });
 
-// isMessage
-test('isMessage returns whether content type is message', (t) => {
-  t.truthy(contentfulEntryHelper.isMessage(messageEntry));
-  t.falsy(contentfulEntryHelper.isMessage(autoReplyEntry));
+// isFaqTemplate
+test('isFaqTemplate returns true if content type is message or faqTemplate', (t) => {
+  t.truthy(contentfulEntryHelper.isFaqAnswer(messageEntry));
+  t.falsy(contentfulEntryHelper.isFaqAnswer(autoReplyEntry));
+  t.truthy(contentfulEntryHelper.isFaqAnswer(faqAnswerFactory.getValidFaqAnswer()));
 });
 
 // isTransitionable

--- a/test/utils/factories/contentful/faqAnswer.js
+++ b/test/utils/factories/contentful/faqAnswer.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const stubs = require('../../stubs');
+
+function getValidFaqAnswer() {
+  const data = {
+    sys: stubs.contentful.getSysWithTypeAndDate('faqAnswer'),
+    fields: {
+      name: stubs.getRandomMessageText(),
+      text: stubs.getRandomMessageText(),
+    },
+  };
+  return data;
+}
+
+module.exports = {
+  getValidFaqAnswer,
+};


### PR DESCRIPTION
#### What's this PR do?

I've added a new Gambit content type called `faqAnswer`, to replace what we use the current `message` content type for -- answering frequently asked questions like "Are you a bot" or "Who is this"  via `defaultTopicTrigger` entries.

There are only a handful of these entries, so I'll manually migrate each one over as a `faqAnswer` once this PR is merged to production.

This `message` type is from way before the days of transition types and is long overdue for a name change (#1094).

Here's an example `faqAnswer` entry I set up for "How old are you?":

<img width="1205" alt="screen shot 2019-01-18 at 3 12 33 pm" src="https://user-images.githubusercontent.com/1236811/51417585-8169fe00-1b33-11e9-9928-a8823a0abbb4.png">


 Once this branch is published, our `what is your age [*]` trigger can reference this instead of the `message` entry it currently references (`4ePqvl7koUo6a2qeSCO0kQ`)

#### How should this be reviewed?

I've set a `testing` keyword to draft so we can test on Gambit Staging. 

<img width="600" alt="screen shot 2019-01-18 at 3 18 40 pm" src="https://user-images.githubusercontent.com/1236811/51417754-68158180-1b34-11e9-99ed-6e398aa5e6c4.png">

**Send `testing` and verify the "Age is just a number" reply is sent.**

<img width="400" alt="screen shot 2019-01-18 at 3 22 11 pm" src="https://user-images.githubusercontent.com/1236811/51417848-ea9e4100-1b34-11e9-818b-4ecd4e1c26b1.png">

#### Any background context you want to provide?

In getting ready to move `defaultTopicTrigger` entries into GraphQL as `conversationTriggers` -- it'd be simpler to avoid redirects to other `defaultTopicTrigger` entries. This means that the `response` reference field on a `defaultTopicTrigger` would only be able to reference the following types:
* `autoReplyTransition`
* `photoPostTransition`
* `textPostTransition`
* `faqAnswer`

#### Relevant tickets
https://github.com/DoSomething/graphql/pull/42

#### Checklist

- [x] Tested on staging.
